### PR TITLE
chore: add CODE_OF_CONDUCT, Issue templates, and README badges

### DIFF
--- a/ai-gateway/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/ai-gateway/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report 🐛
+about: Report something that isn't working correctly
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+**Description**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment:**
+ - OS: [e.g., Linux, macOS, Windows]
+ - Browser: [e.g., Chrome, Safari]
+ - Version: [e.g., v1.0.0]
+
+**Additional Context**
+Add any other context about the problem here.

--- a/ai-gateway/.github/ISSUE_TEMPLATE/documentation.md
+++ b/ai-gateway/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,19 @@
+---
+name: Documentation 📝
+about: Improve or fix documentation
+title: "[Docs] "
+labels: documentation
+assignees: ''
+---
+
+**Location of the documentation**
+Which part of the documentation needs improvement? (e.g., README, DEPLOY.md, inline code comments)
+
+**Describe the issue**
+A clear and concise description of what needs to be changed or added.
+
+**Proposed change**
+If you have a specific change in mind, describe it here.
+
+**Additional context**
+Add any other context about the documentation issue here.

--- a/ai-gateway/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/ai-gateway/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request ✨
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional Context**
+Add any other context or screenshots about the feature request here.

--- a/ai-gateway/CODE_OF_CONDUCT.md
+++ b/ai-gateway/CODE_OF_CONDUCT.md
@@ -1,0 +1,119 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and sexual orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at:
+- Opening a [Discussion](https://github.com/DING-BAOMING/ScoreRoute/discussions)
+- Contacting the maintainers via GitHub
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+extended inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed. Violating these terms
+may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/ai-gateway/README.md
+++ b/ai-gateway/README.md
@@ -1,5 +1,10 @@
 # ScoreRoute - API网关管理系统
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8.svg)](https://golang.org/)
+[![Vue3](https://img.shields.io/badge/Vue-3-green.svg)](https://vuejs.org/)
+[![Release](https://img.shields.io/badge/Release-v1.0.0-blue.svg)](https://github.com/DING-BAOMING/ScoreRoute/releases)
+
 基于Go + Vue3的AI API网关系统，支持多种AI模型的统一接入和轮询调度。
 
 ## 功能特性


### PR DESCRIPTION
## Summary

Add professional open source project infrastructure:

- **CODE_OF_CONDUCT.md**: Based on Contributor Covenant 2.0
- **Issue Templates**: Bug report, Feature request, Documentation
- **README badges**: License, Go version, Vue version, Release

## Changes

- `CODE_OF_CONDUCT.md` - Community conduct guidelines
- `.github/ISSUE_TEMPLATE/bug_report.md` - Bug report template
- `.github/ISSUE_TEMPLATE/feature_request.md` - Feature request template
- `.github/ISSUE_TEMPLATE/documentation.md` - Documentation template
- `README.md` - Added shields.io badges