### PR TITLE
fix: correct binary path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Prepare release files
         run: |
           mkdir -p release
-          cp scoreroute-${{ steps.get_version.outputs.VERSION }}-linux-amd64 release/scoreroute
+          cp ai-gateway/scoreroute-${{ steps.get_version.outputs.VERSION }}-linux-amd64 release/scoreroute
           cp -r ai-gateway/web/dist release/
           cp ai-gateway/docker-compose.yml release/
           cp ai-gateway/.env.example release/


### PR DESCRIPTION
Fix binary path issue in release workflow - the backend binary was being built in ai-gateway directory but Prepare release files step expected it in root.