### PR TITLE
fix: remove port overwrite in install.sh

### DIFF
--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -121,7 +121,6 @@ update_docker_compose() {
     echo -e "${YELLOW}[5/7] 配置 Docker 端口...${NC}"
     
     sed -i "s/\${PORT:-3000}/${PORT}/" docker-compose.yml
-    sed -i 's/\${PORT:-3000}/3000/' docker-compose.yml
     echo -e "${GREEN}✓ 端口已配置为 ${PORT}${NC}"
 }
 


### PR DESCRIPTION
## Summary
- Remove line that unconditionally overwrites user port selection in docker-compose.yml