### PR TITLE
fix: properly fix renderMarkdown - add missing loadDoc declaration

### DIFF
--- a/ai-gateway/web/src/views/Docs.vue
+++ b/ai-gateway/web/src/views/Docs.vue
@@ -124,6 +124,9 @@ function renderMarkdown(text) {
     return '<p>' + escapeHtml(text) + '</p>'
   }
 }
+
+const loadDoc = async (path) => {
+  loading.value = true
   error.value = ''
   currentDoc.value = path
   htmlContent.value = ''


### PR DESCRIPTION
Fix the previous broken fix that accidentally deleted const loadDoc declaration