### PR TITLE
feat: add Gitee mirror support for Chinese users

### DIFF
--- a/ai-gateway/docs/index.html
+++ b/ai-gateway/docs/index.html
@@ -26,6 +26,9 @@
                     <a href="https://demo.scoreroute.com" target="_blank">Demo</a>
                 </div>
                 <div class="nav-cta">
+                    <a href="https://gitee.com/BM-D/ScoreRoute" class="btn btn-secondary" target="_blank" title="Gitee镜像(国内快速)">
+                        <i class="fas fa-cloud"></i> Gitee
+                    </a>
                     <a href="https://github.com/DING-BAOMING/ScoreRoute" class="btn btn-primary" target="_blank">
                         <i class="fab fa-github"></i> GitHub
                     </a>
@@ -44,7 +47,8 @@
             <a href="faq.html">FAQ</a>
                     <a href="https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=82bq51e8-fbd2-4c36-97d9-4e9f575c3d1b" target="_blank">飞书</a>
                     <a href="https://demo.scoreroute.com" target="_blank">Demo</a>
-            <a href="https://github.com/DING-BAOMING/ScoreRoute" target="_blank">GitHub</a>
+            <a href="https://gitee.com/BM-D/ScoreRoute" target="_blank">Gitee</a> |
+                        <a href="https://github.com/DING-BAOMING/ScoreRoute" target="_blank">GitHub</a>
         </div>
     </header>
 
@@ -137,7 +141,11 @@
                         <i class="fas fa-copy"></i> 复制
                     </button>
                 </div>
-                <pre><code>curl -O https://raw.githubusercontent.com/DING-BAOMING/ScoreRoute/main/install.sh && chmod +x install.sh && ./install.sh</code></pre>
+                <pre><code># 国内用户推荐使用 Gitee
+curl -O https://gitee.com/BM-D/ScoreRoute/raw/main/install.sh && chmod +x install.sh && ./install.sh
+
+# GitHub 用户
+curl -O https://raw.githubusercontent.com/DING-BAOMING/ScoreRoute/main/install.sh && chmod +x install.sh && ./install.sh</code></pre>
             </div>
             <p class="text-center mt-4">
                 <a href="quickstart.html" class="btn btn-secondary">查看详细文档</a>
@@ -163,6 +171,7 @@
                 <div class="footer-links">
                     <h5>资源</h5>
                     <ul>
+                        <li><a href="https://gitee.com/BM-D/ScoreRoute" target="_blank">Gitee</a></li>
                         <li><a href="https://github.com/DING-BAOMING/ScoreRoute" target="_blank">GitHub</a></li>
                         <li><a href="faq.html">FAQ</a>
                     <a href="https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=82bq51e8-fbd2-4c36-97d9-4e9f575c3d1b" target="_blank">飞书</a>

--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -9,10 +9,12 @@ NC='\033[0m'
 
 DEFAULT_PORT=3000
 REPO_URL="https://github.com/DING-BAOMING/ScoreRoute.git"
+GITEE_URL="https://gitee.com/BM-D/ScoreRoute.git"
 INSTALL_DIR="${HOME}/scoreroute"
 
 PORT="${PORT:-${DEFAULT_PORT}}"
 NON_INTERACTIVE="${NON_INTERACTIVE:-false}"
+USE_GITEE="${USE_GITEE:-false}"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -20,7 +22,8 @@ while [[ $# -gt 0 ]]; do
         --password) ADMIN_PASSWORD="$2"; shift 2 ;;
         --dir) INSTALL_DIR="$2"; shift 2 ;;
         --non-interactive) NON_INTERACTIVE=true; shift ;;
-        --help|-h) echo "Usage: $0 [--port PORT] [--password PASS] [--dir DIR] [--non-interactive]"; exit 0 ;;
+        --help|-h) echo "Usage: $0 [--port PORT] [--password PASS] [--dir DIR] [--non-interactive] [--gitee]"; exit 0 ;;
+        --gitee) USE_GITEE=true; shift ;;
         *) echo "Unknown: $1"; exit 1 ;;
     esac
 done
@@ -56,7 +59,11 @@ setup_directory() {
     if [ -d ".git" ]; then
         git fetch origin && git reset --hard origin/main
     else
-        git clone "$REPO_URL" .
+        if [ "$USE_GITEE" = "true" ]; then
+            git clone "$GITEE_URL" .
+        else
+            git clone "$REPO_URL" .
+        fi
     fi
     log_ok "目录就绪"
 }


### PR DESCRIPTION
## Changes

1. **官网 (docs/index.html)**:
   - 添加Gitee链接到导航栏
   - 添加Gitee链接到页脚
   - 添加Gitee一键安装命令

2. **一键安装脚本 (install.sh)**:
   - 添加 `--gitee` 标志
   - 国内用户可使用Gitee镜像快速安装

## 使用方法

```bash
# 国内用户
curl -O https://gitee.com/BM-D/ScoreRoute/raw/main/install.sh && chmod +x install.sh && ./install.sh --gitee

# GitHub用户
curl -O https://raw.githubusercontent.com/DING-BAOMING/ScoreRoute/main/install.sh && chmod +x install.sh
```