### PR TITLE
feat: add passwordless mode with initial setup dialog for zero-foundation users

### DIFF
--- a/ai-gateway/internal/handler/auth.go
+++ b/ai-gateway/internal/handler/auth.go
@@ -6,16 +6,19 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"ai-gateway/internal/model"
+	"ai-gateway/internal/repository"
 	"ai-gateway/internal/service"
 )
 
 type AuthHandler struct {
-	service *service.AuthService
+	service    *service.AuthService
+	configRepo *repository.SystemConfigRepo
 }
 
 func NewAuthHandler() *AuthHandler {
 	return &AuthHandler{
-		service: service.NewAuthService(),
+		service:    service.NewAuthService(),
+		configRepo: repository.NewSystemConfigRepo(),
 	}
 }
 
@@ -57,5 +60,47 @@ func (h *AuthHandler) HealthCheck(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"status":  "healthy",
 		"service": "ScoreRoute",
+	})
+}
+
+func (h *AuthHandler) CheckSetupStatus(c *gin.Context) {
+	config, err := h.configRepo.Get()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.APIResponse{
+		Code:    0,
+		Message: "success",
+		Data: gin.H{
+			"password_setup_done": config.PasswordSetupDone,
+			"password_less_mode":  config.PasswordLessMode,
+		},
+	})
+}
+
+func (h *AuthHandler) PasswordLessLogin(c *gin.Context) {
+	config, err := h.configRepo.Get()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: err.Error()})
+		return
+	}
+
+	if !config.PasswordLessMode {
+		c.JSON(http.StatusUnauthorized, model.APIResponse{Code: 401, Message: "密码登录已启用，请使用密码登录"})
+		return
+	}
+
+	token, err := h.service.GenerateTokenForUser("admin")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: "生成令牌失败"})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.APIResponse{
+		Code:    0,
+		Message: "登录成功",
+		Data:    model.LoginResponse{Token: token},
 	})
 }

--- a/ai-gateway/internal/handler/system_config.go
+++ b/ai-gateway/internal/handler/system_config.go
@@ -31,15 +31,16 @@ func (h *SystemConfigHandler) Get(c *gin.Context) {
 
 func (h *SystemConfigHandler) Update(c *gin.Context) {
 	var req struct {
-		ExchangeRate float64 `json:"exchange_rate" binding:"required"`
-		Currency     string  `json:"currency" binding:"required"`
+		ExchangeRate     float64 `json:"exchange_rate" binding:"required"`
+		Currency         string  `json:"currency" binding:"required"`
+		PasswordLessMode bool    `json:"password_less_mode"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "请求参数错误"})
 		return
 	}
 
-	if err := h.repo.Update(req.ExchangeRate, req.Currency); err != nil {
+	if err := h.repo.Update(req.ExchangeRate, req.Currency, req.PasswordLessMode); err != nil {
 		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: err.Error()})
 		return
 	}
@@ -67,4 +68,60 @@ func (h *SystemConfigHandler) UpdateDispatchMode(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, model.APIResponse{Code: 0, Message: "更新成功"})
+}
+
+func (h *SystemConfigHandler) SetupPassword(c *gin.Context) {
+	var req struct {
+		Password string `json:"password" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "密码不能为空"})
+		return
+	}
+
+	if len(req.Password) < 6 {
+		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "密码长度至少6位"})
+		return
+	}
+
+	if err := h.repo.SetupPassword(req.Password); err != nil {
+		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.APIResponse{Code: 0, Message: "密码设置成功"})
+}
+
+func (h *SystemConfigHandler) EnablePasswordLessMode(c *gin.Context) {
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "请求参数错误"})
+		return
+	}
+
+	if err := h.repo.EnablePasswordLessMode(req.Enabled); err != nil {
+		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.APIResponse{Code: 0, Message: "设置成功"})
+}
+
+func (h *SystemConfigHandler) CheckSetupStatus(c *gin.Context) {
+	config, err := h.repo.Get()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.APIResponse{
+		Code:    0,
+		Message: "success",
+		Data: gin.H{
+			"password_setup_done": config.PasswordSetupDone,
+			"password_less_mode":  config.PasswordLessMode,
+		},
+	})
 }

--- a/ai-gateway/internal/model/model.go
+++ b/ai-gateway/internal/model/model.go
@@ -86,11 +86,13 @@ type Token struct {
 }
 
 type SystemConfig struct {
-	ID           int64     `json:"id"`
-	ExchangeRate float64   `json:"exchange_rate"` // CNY to USD rate
-	Currency     string    `json:"currency"`      // base currency for cost calculation
-	DispatchMode string    `json:"dispatch_mode"` // "polling" or "smart"
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID                 int64     `json:"id"`
+	ExchangeRate       float64   `json:"exchange_rate"`       // CNY to USD rate
+	Currency           string    `json:"currency"`            // base currency for cost calculation
+	DispatchMode       string    `json:"dispatch_mode"`       // "polling" or "smart"
+	PasswordLessMode   bool      `json:"password_less_mode"`  // enable password-less access
+	PasswordSetupDone  bool      `json:"password_setup_done"` // password has been configured
+	UpdatedAt          time.Time `json:"updated_at"`
 }
 
 type CallLog struct {

--- a/ai-gateway/internal/repository/db.go
+++ b/ai-gateway/internal/repository/db.go
@@ -462,5 +462,21 @@ func migrateTables() error {
 		log.Println("Channels table already has auto_disabled column, skipping")
 	}
 
+	// Migration: Add password columns to system_config
+	var passwordLessModeCount int
+	row = DB.QueryRow("SELECT COUNT(*) FROM pragma_table_info('system_config') WHERE name='password_less_mode'")
+	if err := row.Scan(&passwordLessModeCount); err != nil {
+		log.Printf("Warning: failed to check password_less_mode column: %v", err)
+	}
+	if passwordLessModeCount == 0 {
+		log.Println("Adding password columns to system_config table...")
+		DB.Exec(`ALTER TABLE system_config ADD COLUMN password_less_mode INTEGER DEFAULT 0`)
+		DB.Exec(`ALTER TABLE system_config ADD COLUMN password_setup_done INTEGER DEFAULT 0`)
+		DB.Exec(`ALTER TABLE system_config ADD COLUMN admin_password TEXT`)
+		log.Println("Password columns added successfully")
+	} else {
+		log.Println("system_config table already has password columns, skipping")
+	}
+
 	return nil
 }

--- a/ai-gateway/internal/repository/system_config.go
+++ b/ai-gateway/internal/repository/system_config.go
@@ -17,17 +17,20 @@ func NewSystemConfigRepo() *SystemConfigRepo {
 func (r *SystemConfigRepo) Get() (*model.SystemConfig, error) {
 	config := &model.SystemConfig{}
 	var dispatchMode sql.NullString
+	var passwordLessMode, passwordSetupDone bool
 	err := DB.QueryRow(
-		`SELECT id, exchange_rate, currency, dispatch_mode, updated_at FROM system_config ORDER BY id DESC LIMIT 1`,
-	).Scan(&config.ID, &config.ExchangeRate, &config.Currency, &dispatchMode, &config.UpdatedAt)
+		`SELECT id, exchange_rate, currency, dispatch_mode, password_less_mode, password_setup_done, updated_at FROM system_config ORDER BY id DESC LIMIT 1`,
+	).Scan(&config.ID, &config.ExchangeRate, &config.Currency, &dispatchMode, &passwordLessMode, &passwordSetupDone, &config.UpdatedAt)
 	if err == sql.ErrNoRows {
 		config = &model.SystemConfig{
-			ExchangeRate: 7.2,
-			Currency:     "CNY",
-			DispatchMode: "polling",
-			UpdatedAt:    time.Now(),
+			ExchangeRate:      7.2,
+			Currency:          "CNY",
+			DispatchMode:      "polling",
+			PasswordLessMode:  false,
+			PasswordSetupDone: false,
+			UpdatedAt:        time.Now(),
 		}
-		if _, err := DB.Exec(`INSERT INTO system_config (exchange_rate, currency, dispatch_mode) VALUES (?, ?, ?)`, config.ExchangeRate, config.Currency, config.DispatchMode); err != nil {
+		if _, err := DB.Exec(`INSERT INTO system_config (exchange_rate, currency, dispatch_mode, password_less_mode, password_setup_done) VALUES (?, ?, ?, ?, ?)`, config.ExchangeRate, config.Currency, config.DispatchMode, config.PasswordLessMode, config.PasswordSetupDone); err != nil {
 			return nil, fmt.Errorf("failed to create system config: %w", err)
 		}
 		return config, nil
@@ -40,13 +43,15 @@ func (r *SystemConfigRepo) Get() (*model.SystemConfig, error) {
 	} else {
 		config.DispatchMode = "polling"
 	}
+	config.PasswordLessMode = passwordLessMode
+	config.PasswordSetupDone = passwordSetupDone
 	return config, nil
 }
 
-func (r *SystemConfigRepo) Update(exchangeRate float64, currency string) error {
+func (r *SystemConfigRepo) Update(exchangeRate float64, currency string, passwordLessMode bool) error {
 	_, err := DB.Exec(
-		`UPDATE system_config SET exchange_rate = ?, currency = ?, updated_at = ?`,
-		exchangeRate, currency, time.Now(),
+		`UPDATE system_config SET exchange_rate = ?, currency = ?, password_less_mode = ?, updated_at = ?`,
+		exchangeRate, currency, passwordLessMode, time.Now(),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to update system config: %w", err)
@@ -63,4 +68,35 @@ func (r *SystemConfigRepo) UpdateDispatchMode(mode string) error {
 		return fmt.Errorf("failed to update dispatch mode: %w", err)
 	}
 	return nil
+}
+
+func (r *SystemConfigRepo) SetupPassword(password string) error {
+	hashedPassword := hashPassword(password)
+	_, err := DB.Exec(
+		`UPDATE system_config SET admin_password = ?, password_setup_done = 1, password_less_mode = 0, updated_at = ?`,
+		hashedPassword, time.Now(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to setup password: %w", err)
+	}
+	return nil
+}
+
+func (r *SystemConfigRepo) EnablePasswordLessMode(enabled bool) error {
+	_, err := DB.Exec(
+		`UPDATE system_config SET password_less_mode = ?, updated_at = ?`,
+		enabled, time.Now(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update passwordless mode: %w", err)
+	}
+	return nil
+}
+
+func hashPassword(password string) string {
+	hash := 0
+	for i, c := range password {
+		hash = hash*31 + int(c) + i
+	}
+	return fmt.Sprintf("%x", hash)
 }

--- a/ai-gateway/internal/router/router.go
+++ b/ai-gateway/internal/router/router.go
@@ -32,6 +32,8 @@ func Setup() *gin.Engine {
 	})
 
 	r.POST("/api/auth/login", handler.NewAuthHandler().Login)
+	r.POST("/api/auth/passwordless-login", handler.NewAuthHandler().PasswordLessLogin)
+	r.GET("/api/auth/setup-status", handler.NewAuthHandler().CheckSetupStatus)
 	r.GET("/health", handler.NewAuthHandler().HealthCheck)
 	r.GET("/api/health", handler.NewAuthHandler().HealthCheck)
 
@@ -121,6 +123,9 @@ func Setup() *gin.Engine {
 			systemConfig.GET("", systemConfigHandler.Get)
 			systemConfig.PUT("", systemConfigHandler.Update)
 			systemConfig.PUT("/dispatch-mode", systemConfigHandler.UpdateDispatchMode)
+			systemConfig.POST("/setup-password", systemConfigHandler.SetupPassword)
+			systemConfig.PUT("/password-less", systemConfigHandler.EnablePasswordLessMode)
+			systemConfig.GET("/setup-status", systemConfigHandler.CheckSetupStatus)
 		}
 
 		extraRating := api.Group("/extra-rating")

--- a/ai-gateway/internal/service/auth.go
+++ b/ai-gateway/internal/service/auth.go
@@ -29,6 +29,10 @@ func (s *AuthService) Login(username, password string) (string, error) {
 		return "", errors.New("用户名或密码错误")
 	}
 
+	return s.GenerateTokenForUser(username)
+}
+
+func (s *AuthService) GenerateTokenForUser(username string) (string, error) {
 	claims := &Claims{
 		Username: username,
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/ai-gateway/web/src/App.vue
+++ b/ai-gateway/web/src/App.vue
@@ -1,8 +1,26 @@
 <template>
   <router-view />
+  <SetupDialog v-if="showSetup" />
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
+import SetupDialog from './components/SetupDialog.vue'
+import axios from 'axios'
+
+const showSetup = ref(false)
+
+onMounted(async () => {
+  try {
+    const response = await axios.get('/api/auth/setup-status')
+    const data = response.data.data
+    if (!data.password_setup_done) {
+      showSetup.value = true
+    }
+  } catch (e) {
+    console.error('Failed to check setup status:', e)
+  }
+})
 </script>
 
 <style>

--- a/ai-gateway/web/src/api/index.js
+++ b/ai-gateway/web/src/api/index.js
@@ -26,7 +26,22 @@ api.interceptors.response.use(
 
 export const authAPI = {
   login: (data) => api.post('/auth/login', data),
-  validate: () => api.get('/auth/validate')
+  validate: () => api.get('/auth/validate'),
+  getSetupStatus: () => {
+    const noAuthApi = axios.create({
+      baseURL: '/api',
+      timeout: 30000
+    })
+    return noAuthApi.get('/auth/setup-status')
+  },
+  passwordLessLogin: () => {
+    const noAuthApi = axios.create({
+      baseURL: '/api',
+      timeout: 30000
+    })
+    return noAuthApi.post('/auth/passwordless-login')
+  },
+  setupPassword: (data) => api.post('/system-config/setup-password', data)
 }
 
 export const channelAPI = {
@@ -65,7 +80,9 @@ export const logAPI = {
   stats: () => api.get('/logs/stats'),
   dashboard: () => api.get('/logs/dashboard'),
   cleanup: (days) => api.delete('/logs/cleanup', { data: { days } }),
-  modelStats: () => api.get('/logs/model-stats')
+  modelStats: () => api.get('/logs/model-stats'),
+  getSystemConfig: () => api.get('/system-config'),
+  setPasswordLessMode: (data) => api.put('/system-config/password-less', data)
 }
 
 export const userRatingAPI = {

--- a/ai-gateway/web/src/components/SetupDialog.vue
+++ b/ai-gateway/web/src/components/SetupDialog.vue
@@ -1,0 +1,280 @@
+<template>
+  <el-dialog
+    v-model="dialogVisible"
+    title="初始设置"
+    width="500px"
+    :close-on-click-modal="false"
+    :show-close="false"
+    draggable
+  >
+    <div class="setup-content">
+      <el-steps :active="step" finish-status="success" align-center>
+        <el-step title="选择模式" />
+        <el-step title="完成" />
+      </el-steps>
+      
+      <div v-if="step === 0" class="step-content">
+        <p class="intro-text">欢迎使用 ScoreRoute API 网关管理系统</p>
+        <p class="intro-text">请选择访问模式：</p>
+        
+        <div class="mode-options">
+          <el-card class="mode-card" shadow="hover" @click="selectMode('password')">
+            <template #header>
+              <div class="mode-header">
+                <el-icon size="24"><Lock /></el-icon>
+                <span>设置密码</span>
+              </div>
+            </template>
+            <div class="mode-desc">
+              需要输入密码才能访问系统<br>
+              <small>更安全，适合生产环境</small>
+            </div>
+          </el-card>
+          
+          <el-card class="mode-card" shadow="hover" @click="selectMode('passwordless')">
+            <template #header>
+              <div class="mode-header">
+                <el-icon size="24"><Key /></el-icon>
+                <span>无需密码</span>
+              </div>
+            </template>
+            <div class="mode-desc">
+              直接访问，无需登录<br>
+              <small>更便捷，适合开发测试</small>
+            </div>
+          </el-card>
+        </div>
+        
+        <el-alert
+          v-if="mode === 'passwordless'"
+          type="warning"
+          :closable="false"
+          show-icon
+          class="warning-alert"
+        >
+          <template #title>
+            安全提示：无需密码模式意味着任何人都可以访问系统管理界面。
+            请确保在可信赖的网络环境下使用。
+          </template>
+        </el-alert>
+        
+        <div v-if="mode === 'password'" class="password-setup">
+          <el-form :model="passwordForm" :rules="passwordRules" ref="passwordFormRef">
+            <el-form-item prop="password">
+              <el-input
+                v-model="passwordForm.password"
+                type="password"
+                placeholder="请输入密码（至少6位）"
+                show-password
+                size="large"
+              />
+            </el-form-item>
+            <el-form-item prop="confirmPassword">
+              <el-input
+                v-model="passwordForm.confirmPassword"
+                type="password"
+                placeholder="请确认密码"
+                show-password
+                size="large"
+              />
+            </el-form-item>
+          </el-form>
+        </div>
+      </div>
+      
+      <div v-if="step === 1" class="step-content success-content">
+        <el-result
+          icon="success"
+          :title="successTitle"
+          :sub-title="successSubTitle"
+        />
+      </div>
+    </div>
+    
+    <template #footer>
+      <div v-if="step === 0">
+        <el-button @click="handleCancel">取消</el-button>
+        <el-button type="primary" @click="handleNext" :disabled="!canProceed">
+          下一步
+        </el-button>
+      </div>
+      <div v-else>
+        <el-button type="primary" @click="handleFinish">开始使用</el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { ElMessage } from 'element-plus'
+import { Lock, Key } from '@element-plus/icons-vue'
+import { useRouter } from 'vue-router'
+import axios from 'axios'
+
+const router = useRouter()
+
+const dialogVisible = ref(true)
+const step = ref(0)
+const mode = ref('')
+const passwordFormRef = ref()
+const passwordForm = ref({
+  password: '',
+  confirmPassword: ''
+})
+
+const passwordRules = {
+  password: [
+    { required: true, message: '请输入密码', trigger: 'blur' },
+    { min: 6, message: '密码长度至少6位', trigger: 'blur' }
+  ],
+  confirmPassword: [
+    { required: true, message: '请确认密码', trigger: 'blur' },
+    { 
+      validator: (rule, value, callback) => {
+        if (value !== passwordForm.value.password) {
+          callback(new Error('两次输入的密码不一致'))
+        } else {
+          callback()
+        }
+      },
+      trigger: 'blur'
+    }
+  ]
+}
+
+const successTitle = computed(() => {
+  if (mode.value === 'passwordless') {
+    return '设置完成'
+  }
+  return '密码已设置'
+})
+
+const successSubTitle = computed(() => {
+  if (mode.value === 'passwordless') {
+    return '已启用无需密码访问模式，您可以直接使用系统'
+  }
+  return '已设置密码，下次登录时需要输入密码'
+})
+
+const canProceed = computed(() => {
+  if (mode.value === 'passwordless') {
+    return true
+  }
+  if (mode.value === 'password') {
+    return passwordForm.value.password.length >= 6 && 
+           passwordForm.value.password === passwordForm.value.confirmPassword
+  }
+  return false
+})
+
+function selectMode(selectedMode) {
+  mode.value = selectedMode
+}
+
+async function handleNext() {
+  if (mode.value === 'passwordless') {
+    try {
+      await axios.put('/api/system-config/password-less', { enabled: true })
+      step.value = 1
+    } catch (e) {
+      ElMessage.error('设置失败：' + (e.message || '未知错误'))
+    }
+  } else if (mode.value === 'password') {
+    const valid = await passwordFormRef.value.validate().catch(() => false)
+    if (!valid) return
+    
+    try {
+      await axios.post('/api/system-config/setup-password', {
+        password: passwordForm.value.password
+      })
+      step.value = 1
+    } catch (e) {
+      ElMessage.error('设置失败：' + (e.message || '未知错误'))
+    }
+  }
+}
+
+function handleCancel() {
+  dialogVisible.value = false
+  router.push('/')
+}
+
+async function handleFinish() {
+  if (mode.value === 'passwordless') {
+    try {
+      const response = await axios.post('/api/auth/passwordless-login')
+      localStorage.setItem('token', response.data.data.token)
+      ElMessage.success('登录成功')
+      router.push('/')
+    } catch (e) {
+      ElMessage.error('登录失败：' + (e.message || '未知错误'))
+    }
+  } else {
+    dialogVisible.value = false
+    router.push('/login')
+  }
+}
+</script>
+
+<style scoped>
+.setup-content {
+  padding: 20px 0;
+}
+
+.step-content {
+  margin-top: 30px;
+}
+
+.intro-text {
+  text-align: center;
+  color: #606266;
+  margin: 10px 0;
+}
+
+.mode-options {
+  display: flex;
+  gap: 20px;
+  margin: 30px 0;
+}
+
+.mode-card {
+  flex: 1;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.mode-card:hover {
+  transform: translateY(-5px);
+}
+
+.mode-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.mode-desc {
+  color: #909399;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.mode-desc small {
+  color: #c0c4cc;
+}
+
+.warning-alert {
+  margin-top: 20px;
+}
+
+.password-setup {
+  margin-top: 20px;
+}
+
+.success-content {
+  padding: 20px 0;
+}
+</style>

--- a/ai-gateway/web/src/views/Dashboard.vue
+++ b/ai-gateway/web/src/views/Dashboard.vue
@@ -155,6 +155,7 @@ const topChannels = ref([])
 const tokenStats = ref([])
 const channelCount = ref(0)
 const tokenCount = ref(0)
+const passwordLessMode = ref(false)
 
 function formatNumber(num) {
   if (!num) return '0'
@@ -169,7 +170,29 @@ function formatNumber(num) {
 
 onMounted(async () => {
   await loadDashboard()
+  await loadSecuritySettings()
 })
+
+async function loadSecuritySettings() {
+  try {
+    const response = await logAPI.getSystemConfig()
+    if (response.code === 0) {
+      passwordLessMode.value = response.data.password_less_mode || false
+    }
+  } catch (e) {
+    console.error('Failed to load security settings:', e)
+  }
+}
+
+async function handlePasswordLessModeChange(value) {
+  try {
+    await logAPI.setPasswordLessMode({ enabled: value })
+    ElMessage.success(value ? '已启用无需密码访问' : '已禁用无需密码访问')
+  } catch (e) {
+    ElMessage.error('设置失败：' + (e.message || '未知错误'))
+    passwordLessMode.value = !value
+  }
+}
 
 async function loadDashboard() {
   try {
@@ -226,6 +249,52 @@ async function loadDashboard() {
   color: #999;
   font-size: 14px;
   margin-top: 5px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.security-settings {
+  padding: 10px 0;
+}
+
+.setting-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 0;
+  border-bottom: 1px solid #ebeef5;
+}
+
+.setting-item:last-of-type {
+  border-bottom: none;
+}
+
+.setting-info {
+  flex: 1;
+}
+
+.setting-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  color: #303133;
+}
+
+.setting-desc {
+  font-size: 13px;
+  color: #909399;
+  margin-top: 5px;
+  margin-left: 32px;
+}
+
+.security-warning {
+  margin-top: 15px;
 }
 
 </style>


### PR DESCRIPTION
## 新增功能: 无需密码模式

### 面向用户
- 目标用户：没有丝毫编程基础的普通用户
- 解决问题：首次使用时的密码设置困惑

### 功能内容
1. **SetupDialog组件** (280行)
   - 首次使用时的引导设置
   - 两个模式选择：设置密码 / 无需密码
   - 适合开发测试环境的便捷选项

2. **Dashboard更新**
   - 根据配置状态显示设置引导

3. **后端支持**
   - passwordless模式支持
   - system_config存储配置

### 用户体验
- 首次打开系统自动弹出设置向导
- 可选择不需要密码直接使用
- 降低使用门槛