### PR TITLE
fix: close setup dialog when clicking start button

### DIFF
--- a/ai-gateway/web/src/components/SetupDialog.vue
+++ b/ai-gateway/web/src/components/SetupDialog.vue
@@ -201,6 +201,7 @@ function handleCancel() {
 }
 
 async function handleFinish() {
+  dialogVisible.value = false
   if (mode.value === 'passwordless') {
     try {
       const response = await axios.post('/api/auth/passwordless-login')


### PR DESCRIPTION
## Summary
- Close setup dialog before making API call
- Improves UX for zero-programming users