### PR TITLE
fix: handle passwordless mode logout correctly

### DIFF
--- a/ai-gateway/web/src/components/SetupDialog.vue
+++ b/ai-gateway/web/src/components/SetupDialog.vue
@@ -176,6 +176,7 @@ async function handleNext() {
   if (mode.value === 'passwordless') {
     try {
       await axios.put('/api/system-config/password-less', { enabled: true })
+      localStorage.setItem('password_less_mode', 'true')
       step.value = 1
     } catch (e) {
       ElMessage.error('设置失败：' + (e.message || '未知错误'))

--- a/ai-gateway/web/src/router/index.js
+++ b/ai-gateway/web/src/router/index.js
@@ -82,12 +82,13 @@ const router = createRouter({
   routes
 })
 
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
   const hasToken = !!localStorage.getItem('token')
+  const passwordLessMode = localStorage.getItem('password_less_mode') === 'true'
   
-  if (to.meta.requiresAuth !== false && !hasToken) {
+  if (to.meta.requiresAuth !== false && !hasToken && !passwordLessMode) {
     next('/login')
-  } else if (to.path === '/login' && hasToken) {
+  } else if (to.path === '/login' && (hasToken || passwordLessMode)) {
     next('/')
   } else {
     next()

--- a/ai-gateway/web/src/views/Dashboard.vue
+++ b/ai-gateway/web/src/views/Dashboard.vue
@@ -283,6 +283,7 @@ async function loadSecuritySettings() {
 async function handlePasswordLessModeChange(value) {
   try {
     await logAPI.setPasswordLessMode({ enabled: value })
+    localStorage.setItem('password_less_mode', value ? 'true' : 'false')
     ElMessage.success(value ? '已启用无需密码访问' : '已禁用无需密码访问')
   } catch (e) {
     ElMessage.error('设置失败：' + (e.message || '未知错误'))


### PR DESCRIPTION
## Summary
- When passwordless mode is enabled and user logs out, re-accessing should not require password login
- Store password_less_mode in localStorage