### PR TITLE
fix: resolve shellcheck SC2034 warnings in install.sh

### DIFF
--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -17,7 +17,7 @@ CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="${CURRENT_DIR}/scoreroute"
 
 PORT="${DEFAULT_PORT}"
-NON_INTERACTIVE="false"
+export NON_INTERACTIVE="false"
 USE_GITEE="false"
 ADMIN_PASSWORD=""
 
@@ -112,7 +112,7 @@ build_and_start() {
     "$DC" down 2>/dev/null || true
     "$DC" up -d --build
     log_info "等待服务启动..."
-    for i in $(seq 1 60); do
+    for _ in $(seq 1 60); do
         if curl -s "http://localhost:${PORT}/health" >/dev/null 2>&1; then
             log_ok "服务启动成功"
             return 0


### PR DESCRIPTION
## Summary
- Export `NON_INTERACTIVE` variable to satisfy shellcheck SC2034 warning
- Use `_` instead of `i` for unused loop counter in health check loop

## Changes
- `install.sh`: Line 20 - Changed `NON_INTERACTIVE="false"` to `export NON_INTERACTIVE="false"`
- `install.sh`: Line 115 - Changed `for i in $(seq 1 60)` to `for _ in $(seq 1 60)`

This fixes the CI shellcheck warnings that were causing the CI status to show as "failure".