### PR TITLE
fix: add port validation to install.sh and sanitize credentials

### DIFF
--- a/ai-gateway/docs/dev/workflow.md
+++ b/ai-gateway/docs/dev/workflow.md
@@ -9,9 +9,9 @@ IMPORTANT: Session start 时执行:
 ## 项目信息
 - **项目路径**: /home/ubuntu/OpenCode/ai-gateway
 - **分支**: main
-- **域名**: https://api.029101.xyz
+- **域名**: https://***REDACTED***
 - **环境**: Docker (生产级)
-- **登录凭证**: admin / dbm52100
+- **登录凭证**: ***REDACTED***/ ***REDACTED***
 
 ## 快速开始
 
@@ -25,10 +25,10 @@ sudo docker-compose down && sudo docker build -t ai-gateway-app:latest . && sudo
 sudo docker logs -f ai-gateway-app-1
 
 # 健康检查
-curl -s https://api.029101.xyz/health
+curl -s https://***REDACTED***/health
 
 # 登录获取token
-curl -s -X POST "https://api.029101.xyz/api/auth/login" -H "Content-Type: application/json" -d '{"username":"admin","password":"dbm52100"}'
+curl -s -X POST "https://***REDACTED***/api/auth/login" -H "Content-Type: application/json" -d '{"username":"***","password":"***"}'
 ```
 
 ## 核心功能
@@ -407,7 +407,7 @@ curl -s -X POST "https://api.029101.xyz/api/auth/login" -H "Content-Type: applic
 ### 已知问题
 | 问题 | 说明 | 处理 |
 |------|------|------|
-| 上游API超时 | api.029101.xyz响应慢 | 非代码问题 |
+| 上游API超时 | ***REDACTED***响应慢 | 非代码问题 |
 | enabled字段类型 | 需要int(1)而非boolean(true) | 需传1 |
 
 ### 系统状态
@@ -432,7 +432,7 @@ curl -s -X POST "https://api.029101.xyz/api/auth/login" -H "Content-Type: applic
 ### 已知问题
 | 问题 | 说明 | 处理 |
 |------|------|------|
-| 上游API超时 | api.029101.xyz响应慢 | 非代码问题 |
+| 上游API超时 | ***REDACTED***响应慢 | 非代码问题 |
 
 ### 系统状态
 - Health: healthy ✅
@@ -471,7 +471,7 @@ curl -s -X POST "https://api.029101.xyz/api/auth/login" -H "Content-Type: applic
 ### 已知问题
 | 问题 | 说明 | 处理 |
 |------|------|------|
-| 上游API慢 | api.029101.xyz响应1.6s-17s | 非代码问题 |
+| 上游API慢 | ***REDACTED***响应1.6s-17s | 非代码问题 |
 
 ### API端点验证
 - /api/extra-rating/config ✅
@@ -604,7 +604,7 @@ curl -s -X POST "https://api.029101.xyz/api/auth/login" -H "Content-Type: applic
 
 ### 问题：Docker自动启动未生效
 
-**问题描述**: ai-gateway-app-1 容器未运行，导致 api.029101.xyz 返回502
+**问题描述**: ai-gateway-app-1 容器未运行，导致 ***REDACTED*** 返回502
 
 **原因分析**: 
 1. docker-compose.yml 配置了 `restart: always`
@@ -630,7 +630,7 @@ docker inspect ai-gateway-app-1 --format '{{.HostConfig.RestartPolicy}}'
 - Health: healthy ✅
 - Docker: ai-gateway-app-1 running ✅
 - Restart Policy: always ✅
-- api.029101.xyz: working ✅
+- ***REDACTED***: working ✅
 
 
 ## 23步执行 (2026-04-23 第五轮)
@@ -641,7 +641,7 @@ docker inspect ai-gateway-app-1 --format '{{.HostConfig.RestartPolicy}}'
 ### 2. 任务完成
 - 2.1 用户报告调查 ✅
 - 2.2 报告分析完成 ✅
-- 2.3 域名测试 ✅ api.029101.xyz 正常
+- 2.3 域名测试 ✅ ***REDACTED*** 正常
 - 2.4 接出API检查 ✅ MiniMax正常工作
 - 2.5 修复完成 ✅ Token创建key保留问题
 
@@ -702,7 +702,7 @@ if req.Key == "" {
 见上方测试API Token表格
 
 ### 20. 前端测试
-https://api.029101.xyz 正常访问
+https://***REDACTED*** 正常访问
 
 ### 21. 修复报告
 已更新: /home/ubuntu/ScoreRoute/Fix/Report.md
@@ -721,7 +721,7 @@ https://api.029101.xyz 正常访问
 - 2.3 无需密码可直接登录 ✅
 - 2.4 仪表盘可关闭密码认证 ✅
 - 2.5 仪表盘可启用密码认证 ✅
-- 2.6 访问 api.029101.xyz ✅
+- 2.6 访问 ***REDACTED*** ✅
 - 2.7 测试验证 ✅
 
 ### 修复记录
@@ -797,7 +797,7 @@ https://api.029101.xyz 正常访问
 
 ### 2. 任务完成 ✅
 - 2.1 调查模型名称显示问题
-- 2.4 访问api.029101.xyz确认正常
+- 2.4 访问***REDACTED***确认正常
 - 2.5-2.6 修复Tokens.vue模型名称简化
 
 ### 主要修复: 模型名称简化

--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ScoreRoute一键安装脚本v2.0.2 完全自动化
+# ScoreRoute一键安装脚本v2.0.3 完全自动化
 set -e
 
 RED='\033[0;31m'
@@ -8,16 +8,14 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 DEFAULT_PORT=3000
-# GitHub仓库根目录包含ai-gateway子目录
 REPO_URL="https://github.com/DING-BAOMING/ScoreRoute.git"
 GITEE_URL="https://gitee.com/BM-D/ScoreRoute.git"
 
-# 默认安装目录为当前目录的scoreroute子目录
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="${CURRENT_DIR}/scoreroute"
 
 PORT="${DEFAULT_PORT}"
-export NON_INTERACTIVE="false"
+NON_INTERACTIVE="false"
 USE_GITEE="false"
 ADMIN_PASSWORD=""
 
@@ -34,7 +32,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 show_banner() {
-    echo -e "${GREEN}ScoreRoute一键安装v2.0.2${NC}"
+    echo -e "${GREEN}ScoreRoute一键安装v2.0.3${NC}"
 }
 
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
@@ -55,6 +53,12 @@ check_docker() {
     log_ok "Docker就绪"
 }
 
+validate_port() {
+    if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+        log_error "端口必须是1-65535之间的数字，当前值: $PORT"
+    fi
+}
+
 setup_directory() {
     log_info "创建目录: $INSTALL_DIR"
     mkdir -p "$INSTALL_DIR"
@@ -72,8 +76,6 @@ setup_directory() {
         fi
     fi
     
-    # GitHub仓库结构是 repo/ai-gateway/
-    # 检查是否需要进入ai-gateway子目录
     if [ -d "ai-gateway" ] && [ ! -f "docker-compose.yml" ]; then
         log_info "进入ai-gateway目录..."
         cd ai-gateway
@@ -112,7 +114,7 @@ build_and_start() {
     "$DC" down 2>/dev/null || true
     "$DC" up -d --build
     log_info "等待服务启动..."
-    for _ in $(seq 1 60); do
+    for i in $(seq 1 60); do
         if curl -s "http://localhost:${PORT}/health" >/dev/null 2>&1; then
             log_ok "服务启动成功"
             return 0
@@ -134,6 +136,7 @@ show_complete() {
 }
 
 show_banner
+validate_port
 check_docker
 setup_directory
 generate_config

--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -15,7 +15,7 @@ CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="${CURRENT_DIR}/scoreroute"
 
 PORT="${DEFAULT_PORT}"
-NON_INTERACTIVE="false"
+export NON_INTERACTIVE="false"
 USE_GITEE="false"
 ADMIN_PASSWORD=""
 
@@ -114,7 +114,7 @@ build_and_start() {
     "$DC" down 2>/dev/null || true
     "$DC" up -d --build
     log_info "等待服务启动..."
-    for i in $(seq 1 60); do
+    for _ in $(seq 1 60); do
         if curl -s "http://localhost:${PORT}/health" >/dev/null 2>&1; then
             log_ok "服务启动成功"
             return 0


### PR DESCRIPTION
## Summary
- Add `validate_port()` function to check port range (1-65535)
- Keep shellcheck fixes from PR #126
- Sanitize workflow.md to remove exposed credentials
- Bump version to v2.0.3

## Changes
- install.sh: Add port validation function
- install.sh: Keep `export NON_INTERACTIVE` (fix SC2034)
- install.sh: Keep `for _ in` (fix SC2034)
- workflow.md: Remove admin/dbm52100 credentials