### PR TITLE
fix: correct docker-compose port mapping for custom ports

### DIFF
--- a/ai-gateway/docker-compose.yml
+++ b/ai-gateway/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     restart: always
     ports:
-      - "${PORT:-3000}:3000"
+      - "${PORT:-3000}:${PORT:-3000}"
     volumes:
       - scoreroute-data:/app/data
       - scoreroute-logs:/app/logs


### PR DESCRIPTION
## Summary
- Fix docker-compose.yml port mapping to use ${PORT:-3000}:${PORT:-3000}
- Previously used ${PORT:-3000}:3000 which broke custom port usage

## Changes
- ai-gateway/docker-compose.yml: Change port mapping from ${PORT}:3000 to ${PORT}:${PORT}

## Verification
- When using --port 50000, the container now correctly maps host:50000 -> container:50000