### PR TITLE
fix: move HEALTHCHECK to docker-compose.yml to support PORT variable

### DIFF
--- a/ai-gateway/Dockerfile
+++ b/ai-gateway/Dockerfile
@@ -37,7 +37,4 @@ ENV GIN_MODE=release
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=5s \
-  CMD wget -q -O- http://localhost:3000/health || exit 1
-
 CMD ["./server"]

--- a/ai-gateway/docker-compose.yml
+++ b/ai-gateway/docker-compose.yml
@@ -18,6 +18,12 @@ services:
       - LOG_PATH=/app/logs
     networks:
       - scoreroute-network
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:${PORT:-3000}/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
 volumes:
   scoreroute-data:


### PR DESCRIPTION
## Summary
- Move HEALTHCHECK from Dockerfile to docker-compose.yml
- HEALTHCHECK now uses ${PORT:-3000} to support custom port installations

## Changes
- Dockerfile: Remove inline HEALTHCHECK
- docker-compose.yml: Add healthcheck with PORT variable support