### PR TITLE
fix: prevent redirect loop when password_less_mode is enabled

### DIFF
--- a/ai-gateway/web/src/api/index.js
+++ b/ai-gateway/web/src/api/index.js
@@ -17,7 +17,9 @@ api.interceptors.response.use(
   response => response.data,
   error => {
     if (error.response?.status === 401) {
+      const passwordLessMode = localStorage.getItem('password_less_mode') === 'true'
       localStorage.removeItem('token')
+      if (passwordLessMode) { return Promise.reject(error); }
       window.location.href = '/login'
     }
     return Promise.reject(error)


### PR DESCRIPTION
## Summary
- Fix redirect loop: when password_less_mode is true and API returns 401, don't redirect to /login to avoid infinite refresh loop