### PR TITLE
fix: improve auto model dispatch and __POLL_ALL__ support

### DIFF
--- a/ai-gateway/internal/service/dispatcher.go
+++ b/ai-gateway/internal/service/dispatcher.go
@@ -367,7 +367,7 @@ func (d *Dispatcher) selectModelAndChannel(token *model.Token, req map[string]in
 
 	modelName, _ := req["model"].(string)
 
-	if modelName == "POLL_ALL" {
+	if modelName == "POLL_ALL" || modelName == "__POLL_ALL__" {
 		modelItem, err = d.modelService.GetNextModelAny()
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get next model: %w", err)
@@ -384,7 +384,7 @@ func (d *Dispatcher) selectModelAndChannel(token *model.Token, req map[string]in
 		if dispatchMode == "smart" {
 			modelItem, err = d.GetNextModelSmart(token.Format, token.Type)
 		} else {
-			modelItem, err = d.modelService.GetNextModelAny()
+			modelItem, err = d.modelService.GetNextModelGlobal(token.Format, token.Type)
 		}
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get next model: %w", err)
@@ -393,7 +393,16 @@ func (d *Dispatcher) selectModelAndChannel(token *model.Token, req map[string]in
 			return nil, nil, fmt.Errorf("no available models")
 		}
 	} else if modelName == "auto" || modelName == "Auto" {
-		modelItem, err = d.GetNextModelSmart(token.Format, token.Type)
+		config, _ := d.systemConfigRepo.Get()
+		dispatchMode := "polling"
+		if config != nil {
+			dispatchMode = config.DispatchMode
+		}
+		if dispatchMode == "smart" {
+			modelItem, err = d.GetNextModelSmart(token.Format, token.Type)
+		} else {
+			modelItem, err = d.modelService.GetNextModelGlobal(token.Format, token.Type)
+		}
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get next model: %w", err)
 		}
@@ -468,7 +477,7 @@ func (d *Dispatcher) DispatchStreamDirect(token *model.Token, requestBody []byte
 
 	modelName, _ := req["model"].(string)
 
-	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__" || modelName == "POLL_ALL"
+	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__" || modelName == "POLL_ALL" || modelName == "__POLL_ALL__" || modelName == "__POLL_ALL__"
 	useAutoSelect := modelName == "auto" || modelName == "Auto"
 
 	var rankedModels []*model.Model
@@ -729,7 +738,7 @@ func (d *Dispatcher) dispatch(token *model.Token, requestBody []byte, forceStrea
 
 	modelName, _ := req["model"].(string)
 
-	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__" || modelName == "POLL_ALL"
+	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__" || modelName == "POLL_ALL" || modelName == "__POLL_ALL__" || modelName == "__POLL_ALL__"
 	useAutoSelect := modelName == "auto" || modelName == "Auto"
 
 	var rankedModels []*model.Model


### PR DESCRIPTION
## 修复内容

### BUG-001: Polling模式下auto模型返回404
- 当dispatchMode为polling时，auto模型现在正确使用GetNextModelGlobal而不是GetNextModelAny
- GetNextModelGlobal会检查format和type，选择兼容的模型

### BUG-003: __POLL_ALL__模型名称支持
- 同时支持POLL_ALL和__POLL_ALL__两种格式
- 已应用到所有代码路径（SelectModelForChat和streaming）

### BUG-002说明
- 禁用渠道后Chat仍然成功是预期行为
- 因为模型可以存在于多个渠道，禁用一个会自动failover到另一个启用该模型的渠道

## 修改文件
- ai-gateway/internal/service/dispatcher.go