### PR TITLE
fix: implement polling failover, CORS security, rate limit headers and API aliases

### DIFF
--- a/ai-gateway/.env.example
+++ b/ai-gateway/.env.example
@@ -27,3 +27,22 @@ ADMIN_PASSWORD=CHANGE_ME_TO_STRONG_PASSWORD
 # 提示: 运行以下命令生成随机密钥:
 # openssl rand -base64 32
 JWT_SECRET=GENERATE_WITH_OPENSSL_COMMAND
+
+# --------------------------------------------
+# CORS 配置 (可选)
+# --------------------------------------------
+
+# CORS允许的源列表，多个用逗号分隔
+# 示例: https://example.com,https://app.example.com
+# 设置为 * 允许所有源 (注意: 不能与 credentials 同时使用)
+# CORS_ALLOWED_ORIGINS=https://example.com
+
+# --------------------------------------------
+# 可选配置
+# --------------------------------------------
+
+# 调度模式: polling 或 smart
+# POLLING_MODE=polling
+
+# 密码less模式: true 或 false (生产环境建议false)
+# PASSWORD_LESS_MODE=false

--- a/ai-gateway/docs/dev/workflow.md
+++ b/ai-gateway/docs/dev/workflow.md
@@ -932,3 +932,45 @@ https://***REDACTED*** 正常访问
 ### Git
 - Branch: fix/unique-model-names
 - Status: 已同步
+
+## 最近修复 (2026-04-26)
+
+### 1. Polling模式Failover机制 ✅
+- **问题**: Polling模式下auto模型返回404
+- **根因**: 只尝试一个模型，无failover
+- **修复**: 
+  - 添加GetNextModelsPolling函数，返回多个模型
+  - 按call_count排序，最低优先
+  - 失败时自动尝试下一个模型
+- **文件**: internal/service/dispatcher.go, internal/service/model.go
+
+### 2. __POLL_ALL__修复 ✅
+- **问题**: __POLL_ALL__模型名称返回404
+- **修复**: 使用polling dispatch路径（带failover）
+- **文件**: internal/service/dispatcher.go
+
+### 3. CORS安全修复 ✅
+- **问题**: wildcard origin时设置credentials有安全风险
+- **修复**: 只在使用具体origin时设置Access-Control-Allow-Credentials
+- **文件**: internal/middleware/auth.go
+
+### 4. NVIDIA渠道模型清理 ✅
+- **问题**: xuetao渠道注册了不支持的模型
+- **修复**: 删除gpt-4, claude-3, gpt-4o等不支持的模型
+- **保留**: meta/llama-*, minimaxai/*, qwen/*
+
+### 5. API路由别名 ✅
+- **问题**: 前端期望的路由返回HTML
+- **修复**: 添加/api/extra-ratings, /api/model-ratings等路由别名
+- **文件**: internal/router/router.go
+
+---
+
+## 测试API Token
+
+| Token | 用途 | 模型 |
+|-------|------|------|
+| sk-test-minimax-27-fixed-12345678 | 固定MiniMax 2.7 | minimaxai/minimax-m2.7 |
+| sk-test-unlimited-auto-fixed-1234 | Auto无限制 | auto |
+| sk-test-1m-hourly-fixed-12345 | Auto有限制 | auto |
+

--- a/ai-gateway/internal/handler/proxy.go
+++ b/ai-gateway/internal/handler/proxy.go
@@ -13,18 +13,21 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"ai-gateway/internal/model"
+	"ai-gateway/internal/repository"
 	"ai-gateway/internal/service"
 )
 
 type ProxyHandler struct {
-	dispatcher *service.Dispatcher
-	tokenSvc   *service.TokenService
+	dispatcher    *service.Dispatcher
+	tokenSvc      *service.TokenService
+	rateLimitRepo *repository.TokenRateLimitRepo
 }
 
 func NewProxyHandler() *ProxyHandler {
 	return &ProxyHandler{
-		dispatcher: service.NewDispatcher(),
-		tokenSvc:   service.NewTokenService(),
+		dispatcher:    service.NewDispatcher(),
+		tokenSvc:      service.NewTokenService(),
+		rateLimitRepo: repository.NewTokenRateLimitRepo(),
 	}
 }
 
@@ -58,6 +61,8 @@ func (h *ProxyHandler) Handle(c *gin.Context) {
 		return
 	}
 
+	h.setRateLimitHeaders(c, token)
+
 	body, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"message": "Failed to read request body"}})
@@ -77,6 +82,7 @@ func (h *ProxyHandler) Handle(c *gin.Context) {
 	if err != nil {
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "rate limit") {
+			h.setRateLimitHeaders(c, token)
 			c.JSON(http.StatusTooManyRequests, gin.H{"error": gin.H{"message": errMsg}})
 		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": errMsg}})
@@ -89,6 +95,65 @@ func (h *ProxyHandler) Handle(c *gin.Context) {
 	}
 
 	c.Data(statusCode, "application/json", respBody)
+}
+
+func (h *ProxyHandler) setRateLimitHeaders(c *gin.Context, token *model.Token) {
+	if token.RateLimits == "" || token.RateLimits == "[]" {
+		return
+	}
+
+	var rules []model.RateLimitRule
+	if err := json.Unmarshal([]byte(token.RateLimits), &rules); err != nil {
+		return
+	}
+
+	for idx, rule := range rules {
+		if rule.Type == "calls" || rule.Type == "tokens" {
+			usage, err := h.rateLimitRepo.GetUsage(token.ID, idx)
+			if err != nil {
+				continue
+			}
+
+			var remaining int64
+			var reset int64
+
+			if usage == nil {
+				remaining = rule.MaxCount
+				reset = time.Now().Add(getWindowDuration(rule.Window)).Unix()
+			} else {
+				remaining = rule.MaxCount - usage.CurrentCount
+				if remaining < 0 {
+					remaining = 0
+				}
+				reset = usage.WindowStart.Add(getWindowDuration(rule.Window)).Unix()
+			}
+
+			prefix := "X-RateLimit-"
+			if rule.Type == "tokens" {
+				prefix = "X-RateLimit-Tokens-"
+			}
+
+			c.Header(prefix+"Limit", fmt.Sprintf("%d", rule.MaxCount))
+			c.Header(prefix+"Remaining", fmt.Sprintf("%d", remaining))
+			c.Header(prefix+"Reset", fmt.Sprintf("%d", reset))
+			break
+		}
+	}
+}
+
+func getWindowDuration(window string) time.Duration {
+	switch window {
+	case "second":
+		return time.Second
+	case "minute":
+		return time.Minute
+	case "hour":
+		return time.Hour
+	case "day":
+		return 24 * time.Hour
+	default:
+		return time.Hour
+	}
 }
 
 func (h *ProxyHandler) HandleStream(c *gin.Context) {
@@ -121,6 +186,8 @@ func (h *ProxyHandler) HandleStream(c *gin.Context) {
 		return
 	}
 
+	h.setRateLimitHeaders(c, token)
+
 	body, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"message": "Failed to read request body"}})
@@ -136,6 +203,7 @@ func (h *ProxyHandler) HandleStreamWithBody(c *gin.Context, token *model.Token, 
 	if err != nil {
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "rate limit") {
+			h.setRateLimitHeaders(c, token)
 			c.JSON(http.StatusTooManyRequests, gin.H{"error": gin.H{"message": errMsg}})
 		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": errMsg}})
@@ -143,6 +211,8 @@ func (h *ProxyHandler) HandleStreamWithBody(c *gin.Context, token *model.Token, 
 		return
 	}
 	defer streamResp.Resp.Body.Close()
+
+	h.setRateLimitHeaders(c, token)
 
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Transfer-Encoding", "chunked")

--- a/ai-gateway/internal/middleware/auth.go
+++ b/ai-gateway/internal/middleware/auth.go
@@ -66,6 +66,7 @@ func CORSMiddleware() gin.HandlerFunc {
 			}
 			if originAllowed {
 				c.Header("Access-Control-Allow-Origin", origin)
+				c.Header("Access-Control-Allow-Credentials", "true")
 			}
 		} else if allowedOrigins == "*" {
 			c.Header("Access-Control-Allow-Origin", "*")
@@ -74,7 +75,6 @@ func CORSMiddleware() gin.HandlerFunc {
 		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		c.Header("Access-Control-Max-Age", "86400")
-		c.Header("Access-Control-Allow-Credentials", "true")
 
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(204)

--- a/ai-gateway/internal/router/router.go
+++ b/ai-gateway/internal/router/router.go
@@ -147,6 +147,39 @@ func Setup() *gin.Engine {
 			modelRating.GET("/cost-time", modelRatingHandler.GetCostTimeRatings)
 			modelRating.GET("/scores", modelRatingHandler.GetAllScores)
 		}
+
+		extraRatings := api.Group("/extra-ratings")
+		{
+			extraRatingHandler := handler.NewExtraRatingHandler()
+			extraRatings.GET("", extraRatingHandler.GetRecords)
+			extraRatings.GET("/config", extraRatingHandler.GetConfig)
+			extraRatings.PUT("/config", extraRatingHandler.SetConfig)
+			extraRatings.GET("/records", extraRatingHandler.GetRecords)
+			extraRatings.DELETE("/records", extraRatingHandler.ClearRecords)
+			extraRatings.DELETE("/records/:id", extraRatingHandler.DeleteRecord)
+			extraRatings.GET("/model-scores", extraRatingHandler.GetAllModelExtraScores)
+		}
+
+		modelRatings := api.Group("/model-ratings")
+		{
+			modelRatingHandler := handler.NewModelRatingHandler()
+			modelRatings.GET("", modelRatingHandler.GetAllScores)
+			modelRatings.GET("/weights", modelRatingHandler.GetWeights)
+			modelRatings.PUT("/weights", modelRatingHandler.UpdateWeights)
+			modelRatings.GET("/cost-time", modelRatingHandler.GetCostTimeRatings)
+			modelRatings.GET("/scores", modelRatingHandler.GetAllScores)
+		}
+
+		sampleAnalysisConfig := api.Group("/sample-analysis-config")
+		{
+			sampleAnalysisHandler := handler.NewSampleAnalysisHandler()
+			sampleAnalysisConfig.GET("", sampleAnalysisHandler.GetConfig)
+		}
+
+		invocations := api.Group("/invocations")
+		{
+			invocations.GET("", handler.NewLogHandler().List)
+		}
 	}
 
 	v1 := r.Group("/v1")

--- a/ai-gateway/internal/service/dispatcher.go
+++ b/ai-gateway/internal/service/dispatcher.go
@@ -175,6 +175,30 @@ type modelRatingWeights struct {
 	TimeRatingWeight   float64
 }
 
+
+
+func (d *Dispatcher) GetNextModelsPolling(format, modelType string, limit int) ([]*model.Model, error) {
+	allModels, err := d.modelService.ListEnabledModels(format, modelType)
+	if err != nil || len(allModels) == 0 {
+		return nil, err
+	}
+
+	// Sort by call_count (polling = lowest first)
+	sortedModels := make([]*model.Model, len(allModels))
+	copy(sortedModels, allModels)
+	for i := 0; i < len(sortedModels)-1; i++ {
+		for j := i + 1; j < len(sortedModels); j++ {
+			if sortedModels[i].CallCount > sortedModels[j].CallCount {
+				sortedModels[i], sortedModels[j] = sortedModels[j], sortedModels[i]
+			}
+		}
+	}
+
+	if len(sortedModels) > limit {
+		return sortedModels[:limit], nil
+	}
+	return sortedModels, nil
+}
 func (d *Dispatcher) getModelRatingWeights() (*modelRatingWeights, error) {
 	repo := repository.NewModelRatingConfigRepo()
 	repoWeights, err := repo.GetAll()
@@ -477,26 +501,26 @@ func (d *Dispatcher) DispatchStreamDirect(token *model.Token, requestBody []byte
 
 	modelName, _ := req["model"].(string)
 
-	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__" || modelName == "POLL_ALL" || modelName == "__POLL_ALL__" || modelName == "__POLL_ALL__"
+	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__"
+	usePollingDispatch := modelName == "POLL_ALL" || modelName == "__POLL_ALL__"
 	useAutoSelect := modelName == "auto" || modelName == "Auto"
 
 	var rankedModels []*model.Model
 	var err error
 
-	if useAutoSelect {
+	if useAutoSelect || usePollingDispatch {
 		config, _ := d.systemConfigRepo.Get()
 		dispatchMode := "polling"
 		if config != nil {
 			dispatchMode = config.DispatchMode
 		}
-		if dispatchMode == "smart" {
+		if dispatchMode == "smart" && !usePollingDispatch {
 			rankedModels, err = d.GetRankedModelsSmart(token.Format, token.Type, 3)
 		} else {
-			selectedModel, err := d.modelService.GetNextModelGlobal(token.Format, token.Type)
-			if err != nil || selectedModel == nil {
-				return nil, 0, err
+			rankedModels, err = d.GetNextModelsPolling(token.Format, token.Type, 3)
+			if err != nil || len(rankedModels) == 0 {
+				return nil, 0, fmt.Errorf("no available models for format=%s type=%s", token.Format, token.Type)
 			}
-			rankedModels = []*model.Model{selectedModel}
 		}
 	} else if useSmartDispatch {
 		rankedModels, err = d.GetRankedModelsSmart(token.Format, token.Type, 3)
@@ -738,26 +762,26 @@ func (d *Dispatcher) dispatch(token *model.Token, requestBody []byte, forceStrea
 
 	modelName, _ := req["model"].(string)
 
-	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__" || modelName == "POLL_ALL" || modelName == "__POLL_ALL__" || modelName == "__POLL_ALL__"
+	useSmartDispatch := modelName == "AUTO" || modelName == "__AUTO__"
+	usePollingDispatch := modelName == "POLL_ALL" || modelName == "__POLL_ALL__"
 	useAutoSelect := modelName == "auto" || modelName == "Auto"
 
 	var rankedModels []*model.Model
 	var err error
 
-	if useAutoSelect {
+	if useAutoSelect || usePollingDispatch {
 		config, _ := d.systemConfigRepo.Get()
 		dispatchMode := "polling"
 		if config != nil {
 			dispatchMode = config.DispatchMode
 		}
-		if dispatchMode == "smart" {
+		if dispatchMode == "smart" && !usePollingDispatch {
 			rankedModels, err = d.GetRankedModelsSmart(token.Format, token.Type, 3)
 		} else {
-			selectedModel, err := d.modelService.GetNextModelGlobal(token.Format, token.Type)
-			if err != nil || selectedModel == nil {
-				return nil, 0, err
+			rankedModels, err = d.GetNextModelsPolling(token.Format, token.Type, 3)
+			if err != nil || len(rankedModels) == 0 {
+				return nil, 0, fmt.Errorf("no available models for format=%s type=%s", token.Format, token.Type)
 			}
-			rankedModels = []*model.Model{selectedModel}
 		}
 	} else if useSmartDispatch {
 		rankedModels, err = d.GetRankedModelsSmart(token.Format, token.Type, 3)

--- a/ai-gateway/internal/service/model.go
+++ b/ai-gateway/internal/service/model.go
@@ -72,6 +72,21 @@ func (s *ModelService) ListEnabled() ([]*model.Model, error) {
 	return s.repo.ListEnabled()
 }
 
+func (s *ModelService) ListEnabledModels(format, modelType string) ([]*model.Model, error) {
+	allModels, err := s.repo.ListEnabled()
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []*model.Model
+	for _, m := range allModels {
+		if m.Format == format && (modelType == "" || m.Type == modelType) {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered, nil
+}
+
 func (s *ModelService) GetByName(name string) (*model.Model, error) {
 	return s.repo.GetByName(name)
 }

--- a/ai-gateway/session_state.md
+++ b/ai-gateway/session_state.md
@@ -1,0 +1,41 @@
+# ScoreRoute Session State
+**最后更新**: 2026-04-26
+
+## 当前版本
+- **版本**: v2.23.1
+- **Commit**: cd15a4e
+- **分支**: main
+- **状态**: ahead of origin/main by 2 commits
+
+## 已修复的问题 (Iteration 32)
+1. ✅ BUG-001: Polling + auto 返回404
+2. ✅ BUG-003: __POLL_ALL__ 返回404
+3. ✅ ISSUE-001: NVIDIA渠道不支持的模型
+4. ✅ ISSUE-007: API路由返回HTML
+5. ✅ ISSUE-003: CORS安全风险
+
+## 仍需处理
+1. ⚠️ ISSUE-004: Rate Limit响应头
+2. ⚠️ ISSUE-005: password_less_mode安全审查
+3. ⚠️ ISSUE-006: 前端bundle优化
+
+## 系统状态
+- 健康检查: ✅ healthy
+- Docker: ✅ 运行中 (端口50000)
+- 调度模式: polling
+
+## Git状态
+```
+On branch main
+Your branch is ahead of 'origin/main' by 2 commits.
+nothing to commit, working tree clean
+```
+
+## 待推送提交
+1. cd15a4e - fix: implement polling failover and CORS security improvements
+2. 436c631 - fix: add missing API route aliases for frontend compatibility
+
+## 测试Token
+- sk-test-minimax-27-fixed-12345678 (固定模型)
+- sk-test-unlimited-auto-fixed-1234 (无限制auto)
+- sk-test-1m-hourly-fixed-12345 (有限制auto)

--- a/ai-gateway/web/vite.config.js
+++ b/ai-gateway/web/vite.config.js
@@ -24,6 +24,14 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    assetsDir: 'assets'
+    assetsDir: 'assets',
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-vue': ['vue', 'vue-router'],
+        }
+      }
+    },
+    chunkSizeWarningLimit: 600
   }
 })


### PR DESCRIPTION
## 修复内容

### 1. Polling Failover (cd15a4e)
- 实现Polling模式下的故障转移
- 当主渠道失败时自动切换到备用渠道

### 2. CORS安全改进 (cd15a4e)
- 改进CORS配置
- 添加可选配置到.env.example

### 3. Rate Limit Headers (06af7a9)
- 添加速率限制响应头
- 优化前端bundle大小

### 4. API Route Aliases (436c631)
- 添加缺失的API路由别名
- 提高前端兼容性

## 修改文件
- ai-gateway/internal/service/dispatcher.go
- ai-gateway/web/src/...
- ai-gateway/.env.example
- docs/workflow.md