### PR TITLE
fix: remove duplicate API routes and improve UserRating field handling

### DIFF
--- a/ai-gateway/internal/handler/user_rating.go
+++ b/ai-gateway/internal/handler/user_rating.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -20,19 +21,47 @@ func NewUserRatingHandler() *UserRatingHandler {
 	}
 }
 
+type UserRatingUpsertRequest struct {
+	ModelName  string `json:"model_name"`
+	UserRating int    `json:"user_rating"`
+	Rating     int    `json:"rating"`
+}
+
+func (r *UserRatingUpsertRequest) ParseAndValidate() (*model.UserRatingRequest, error) {
+	userRating := r.UserRating
+	if userRating == 0 && r.Rating != 0 {
+		userRating = r.Rating
+	}
+
+	if userRating < 1 || userRating > 100 {
+		return nil, &json.UnmarshalTypeError{}
+	}
+
+	return &model.UserRatingRequest{
+		ModelName:  r.ModelName,
+		UserRating: userRating,
+	}, nil
+}
+
 func (h *UserRatingHandler) Upsert(c *gin.Context) {
-	var req model.UserRatingRequest
+	var req UserRatingUpsertRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "无效的请求: " + err.Error()})
+		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "无效的请求: 请使用 user_rating 字段(值范围1-100)"})
 		return
 	}
 
-	if req.UserRating < 1 || req.UserRating > 100 {
-		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "评分必须在1-100之间"})
+	validReq, err := req.ParseAndValidate()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "评分必须在1-100之间，请使用 user_rating 或 rating 字段"})
 		return
 	}
 
-	if err := h.service.UpsertRating(&req); err != nil {
+	if validReq.ModelName == "" {
+		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "model_name 为必填字段"})
+		return
+	}
+
+	if err := h.service.UpsertRating(validReq); err != nil {
 		c.JSON(http.StatusInternalServerError, model.APIResponse{Code: 500, Message: err.Error()})
 		return
 	}

--- a/ai-gateway/internal/router/router.go
+++ b/ai-gateway/internal/router/router.go
@@ -148,7 +148,6 @@ func Setup() *gin.Engine {
 		{
 			extraRatingHandler := handler.NewExtraRatingHandler()
 			extraRatings.GET("", extraRatingHandler.GetRecords)
-			extraRatings.GET("/records", extraRatingHandler.GetRecords)
 			extraRatings.GET("/config", extraRatingHandler.GetConfig)
 			extraRatings.PUT("/config", extraRatingHandler.SetConfig)
 			extraRatings.PUT("/penalty", extraRatingHandler.UpdatePenalty)
@@ -167,10 +166,6 @@ func Setup() *gin.Engine {
 			modelRating.GET("/scores", modelRatingHandler.GetAllScores)
 		}
 
-		invocations := api.Group("/invocations")
-		{
-			invocations.GET("", handler.NewLogHandler().List)
-		}
 	}
 
 	v1 := r.Group("/v1")


### PR DESCRIPTION
## Summary
- Remove duplicate /api/extra-ratings/records route (same handler as /api/extra-ratings)
- Remove duplicate /api/invocations route (same handler as /api/logs)
- Accept both "rating" and "user_rating" fields in UserRating API for better UX
- Improve error messages to guide users on correct field names

## Changes
### router.go
- Removed duplicate extraRatings.GET("/records") route
- Removed duplicate invocations route group

### user_rating.go
- Added Rating field as alias for UserRating
- Custom ParseAndValidate to accept both field names
- Improved error messages

## Fixes
- Fixes #204 (duplicate API endpoints)
- Fixes #201 (field naming inconsistency)