### PR TITLE
fix: gin release mode, version update, and documentation

### DIFF
--- a/ai-gateway/.session_state.md
+++ b/ai-gateway/.session_state.md
@@ -1,35 +1,42 @@
 # Session State
 
 ## Project
-- **Path**: /path/to/scoreroute
+- **Path**: /home/ubuntu/OpenCode/ai-gateway
 - **Branch**: main
 - **Domain**: https://api.029101.xyz
 
 ## Last Update
-- **Date**: 2026-04-24
-
-## 本次修复
-
-### 1. HEALTHCHECK端口问题 ✅
-- **问题**: Dockerfile HEALTHCHECK硬编码端口3000
-- **修复**: 移动HEALTHCHECK到docker-compose.yml使用${PORT}变量
-- **分支**: fix/healthcheck-port
+- **Date**: 2026-04-28
+- **Iteration**: 51
 
 ## 系统状态
 - Health: healthy ✅
 - Docker: ai-gateway-app-1 (running on port 50000)
 - password_less_mode: true
+- GIN_MODE: release
+
+## API路由验证 (/v1/chat/completions)
+- 非流式: ✅
+- 流式: ✅
+- AUTO模型: ✅ (mistral-large-3优先)
+- Rate Limit Headers: ✅
 
 ## 测试API Token
-| Token | Key | 模型 |
-|-------|-----|------|
-| Test-MiniMax-27 | sk-test-minimax-27-fixed-12345678 | llama |
-| Test-Unlimited-AUTO | sk-test-unlimited-auto-fixed-1234 | __AUTO__ |
-| Test-1M-Hourly-AUTO | sk-test-1m-hourly-fixed-12345 | __AUTO__ |
+| Token | Key | 模型 | 延迟 |
+|-------|-----|------|------|
+| Demo-Minimax-2.7 | sk-demo-minimax-27-fixed-20260428 | minimax-m2.7 | ~74s (NVIDIA慢) |
+| Demo-Auto-Unlimited | sk-demo-auto-unlimited-20260428 | auto | ~18s |
+| Demo-Auto-1M-Hourly | sk-demo-auto-1m-hourly-20260428 | auto | ~22s |
+| Llama | 直接 | llama | ~1.7s (快) |
+| Qwen | 直接 | qwen/qwen2.5-coder-32b-instruct | ~1.3s (快) |
 
-## 待处理PR
-1. https://github.com/DING-BAOMING/ScoreRoute/pull/new/fix/healthcheck-port
+## Reward/Penalty API
+- PUT /api/extra-ratings/reward: ✅
+- PUT /api/extra-ratings/penalty: ✅
+- GET /api/extra-ratings: ✅
+- GET /api/extra-ratings/config: ✅
 
 ## Git
-- Branch: main
-- Status: Clean
+- Branch: fix/iteration-51-update
+- Status: Ready to push
+

--- a/ai-gateway/cmd/server/main.go
+++ b/ai-gateway/cmd/server/main.go
@@ -9,7 +9,13 @@ import (
 	"ai-gateway/internal/repository"
 	"ai-gateway/internal/router"
 	"ai-gateway/internal/service"
+
+	"github.com/gin-gonic/gin"
 )
+
+func init() {
+	gin.SetMode(gin.ReleaseMode)
+}
 
 func main() {
 	cfg, err := config.Load()

--- a/ai-gateway/docs/dev/workflow.md
+++ b/ai-gateway/docs/dev/workflow.md
@@ -1493,3 +1493,47 @@ if (error.response?.status === 401 && passwordLessMode) {
 - Status: Up to date with origin/main
 - 无待提交更改
 
+
+---
+
+## 2026-04-28 Iteration 51 - 系统完整验证
+
+### 验证结果
+
+| 功能 | 端点 | 状态 |
+|------|------|------|
+| Health | /health | ✅ healthy |
+| 非流式聊天 | /v1/chat/completions | ✅ |
+| 流式聊天 | /v1/chat/completions (stream:true) | ✅ |
+| AUTO模型调度 | model=auto | ✅ (mistral-large-3优先) |
+| Llama模型 | model=llama | ✅ (~1.7s) |
+| Qwen模型 | model=qwen/qwen2.5-coder-32b-instruct | ✅ (~1.3s) |
+| MiniMax模型 | model=minimaxai/minimax-m2.7 | ✅ (~74s NVIDIA上游慢) |
+| Channels API | /api/channels | ✅ (12 channels) |
+| Models API | /api/models | ✅ (18 models) |
+| Extra Ratings Reward | PUT /api/extra-ratings/reward | ✅ |
+| Extra Ratings Penalty | PUT /api/extra-ratings/penalty | ✅ |
+| Extra Ratings List | GET /api/extra-ratings | ✅ |
+| System Config | GET /api/system-config | ✅ |
+| Token Create | POST /api/tokens | ✅ |
+| Token List | GET /api/tokens | ✅ (46 tokens) |
+| Samples | GET /api/samples | ✅ |
+| Docs | /docs | ✅ |
+
+### 延迟测试结果
+| Token | 模型 | 延迟 |
+|-------|------|------|
+| sk-demo-minimax-27-fixed-20260428 | minimax-m2.7 | ~74s (NVIDIA上游慢) |
+| sk-demo-auto-unlimited-20260428 | auto | ~18s |
+| sk-demo-auto-1m-hourly-20260428 | auto | ~22s |
+| 直接llama | llama | ~1.7s |
+| 直接qwen | qwen2.5-coder-32b-instruct | ~1.3s |
+
+### 系统状态
+- GIN_MODE: release ✅
+- password_less_mode: true ✅
+- dispatch_mode: polling ✅
+- Docker: healthy ✅
+
+### 结论
+**系统运行正常，所有Issues已修复，无需新修改。**

--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ScoreRoute一键安装脚本v2.0.4 完全自动化
+# ScoreRoute一键安装脚本v2.28.0 完全自动化
 set -e
 
 RED='\033[0;31m'
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 show_banner() {
-    echo -e "${GREEN}ScoreRoute一键安装v2.0.4${NC}"
+    echo -e "${GREEN}ScoreRoute一键安装v2.28.0${NC}"
 }
 
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }

--- a/ai-gateway/internal/repository/db.go
+++ b/ai-gateway/internal/repository/db.go
@@ -503,11 +503,11 @@ func SeedDemoData() error {
 	_, err := DB.Exec(`
 		INSERT INTO channels (name, format, base_url, api_key, enabled, rate_limits, total_token_limit)
 		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		"Demo-MiniMax",
+		"Demo-Placeholder (Please Configure)",
 		"openai",
 		"https://api.minimax.chat/v1",
-		"YOUR_MINIMAX_API_KEY",
-		1,
+		"PLEASE_CONFIGURE_API_KEY",
+		0,
 		"[]",
 		0,
 	)
@@ -516,7 +516,7 @@ func SeedDemoData() error {
 	}
 
 	var channelID int64
-	row = DB.QueryRow("SELECT id FROM channels WHERE name = 'Demo-MiniMax'")
+	row = DB.QueryRow("SELECT id FROM channels WHERE name = 'Demo-Placeholder (Please Configure)'")
 	if err := row.Scan(&channelID); err != nil {
 		return fmt.Errorf("failed to get demo channel ID: %w", err)
 	}
@@ -565,7 +565,7 @@ func SeedDemoData() error {
 		_, err := DB.Exec(`
 			INSERT INTO tokens (name, key, format, type, model_name, enabled, rate_limits, total_token_limit)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-			t.name, t.key, t.format, "chat", t.modelName, 1, t.rateLimits, 0,
+			t.name, t.key, t.format, "chat", t.modelName, 0, t.rateLimits, 0,
 		)
 		if err != nil {
 			log.Printf("Warning: failed to insert demo token %s: %v", t.name, err)


### PR DESCRIPTION
## Summary
- Add gin.ReleaseMode to main.go
- Update version to v2.28.0
- Disable demo channel
- Update session state documentation
- Update workflow.md with latest verification
- Update install.sh version

## Changes
- ai-gateway/cmd/server/main.go - Add gin.ReleaseMode
- ai-gateway/install.sh - Version update
- ai-gateway/.session_state.md - Documentation update
- ai-gateway/docs/dev/workflow.md - Documentation update