### PR TITLE
fix: dispatcher uses model_name for routing and batch create fix

### DIFF
--- a/ai-gateway/internal/repository/model_repo.go
+++ b/ai-gateway/internal/repository/model_repo.go
@@ -343,6 +343,29 @@ func (r *ModelRepo) GetByName(name string) (*model.Model, error) {
 	return model, nil
 }
 
+func (r *ModelRepo) GetByModelName(modelName string) (*model.Model, error) {
+	if modelName == "" {
+		return nil, nil
+	}
+	model := &model.Model{}
+	err := DB.QueryRow(
+		`SELECT m.id, m.channel_id, m.name, m.model_name, m.type, m.enabled, m.call_count, m.rate_limits, m.total_token_limit, m.expires_at, m.total_calls, m.total_tokens, m.cost_per_token, m.currency, m.created_at, c.name as channel_name, c.format as channel_format
+		 FROM models m LEFT JOIN channels c ON m.channel_id = c.id
+		 WHERE m.model_name = ? AND m.enabled = 1 AND m.auto_disabled = 0 AND c.enabled = 1
+		 ORDER BY m.call_count ASC LIMIT 1`,
+		modelName,
+	).Scan(&model.ID, &model.ChannelID, &model.Name, &model.ModelName, &model.Type, &model.Enabled, &model.CallCount, &model.RateLimits, &model.TotalTokenLimit, &model.ExpiresAt, &model.TotalCalls, &model.TotalTokens, &model.CostPerToken, &model.Currency, &model.CreatedAt, &model.ChannelName, &model.Format)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	DB.Exec(`UPDATE models SET call_count = call_count + 1 WHERE id = ?`, model.ID)
+	DB.Exec(`UPDATE channels SET call_count = call_count + 1 WHERE id = ?`, model.ChannelID)
+	return model, nil
+}
+
 func (r *ModelRepo) GetByNamePrefix(prefix string) ([]*model.Model, error) {
 	rows, err := DB.Query(
 		`SELECT m.id, m.channel_id, m.name, m.model_name, m.type, m.enabled, m.call_count, m.rate_limits, m.total_token_limit, m.expires_at, m.total_calls, m.total_tokens, m.cost_per_token, m.currency, m.created_at, c.name as channel_name, c.format as channel_format

--- a/ai-gateway/internal/service/dispatcher.go
+++ b/ai-gateway/internal/service/dispatcher.go
@@ -434,10 +434,19 @@ func (d *Dispatcher) selectModelAndChannel(token *model.Token, req map[string]in
 			return nil, nil, fmt.Errorf("no available models for format=%s type=%s", token.Format, token.Type)
 		}
 	} else if modelName != "" {
-		modelItem, err = d.modelService.GetByName(modelName)
+		// First try exact match on model_name (upstream API name)
+		modelItem, err = d.modelService.GetByModelName(modelName)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get model: %w", err)
 		}
+		// If not found, try name (display name)
+		if modelItem == nil {
+			modelItem, err = d.modelService.GetByName(modelName)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get model: %w", err)
+			}
+		}
+		// If still not found, try prefix match
 		if modelItem == nil {
 			prefixModels, err := d.modelService.GetByNamePrefix(normalizeModelNameForPrefix(modelName))
 			if err != nil {
@@ -589,7 +598,12 @@ func (d *Dispatcher) DispatchStreamDirect(token *model.Token, requestBody []byte
 
 		url := strings.TrimSuffix(selectedChannel.BaseURL, "/") + "/chat/completions"
 
-		req["model"] = modelItem.Name
+		// Use ModelName if available, otherwise fall back to Name for backward compatibility
+		modelNameForAPI := modelItem.Name
+		if modelItem.ModelName != "" {
+			modelNameForAPI = modelItem.ModelName
+		}
+		req["model"] = modelNameForAPI
 		modifiedBody, err := json.Marshal(req)
 		if err != nil {
 			lastErr = fmt.Errorf("failed to marshal request: %w", err)
@@ -862,7 +876,12 @@ func (d *Dispatcher) dispatch(token *model.Token, requestBody []byte, forceStrea
 
 		url := strings.TrimSuffix(selectedChannel.BaseURL, "/") + "/chat/completions"
 
-		req["model"] = modelItem.Name
+		// Use ModelName if available, otherwise fall back to Name for backward compatibility
+		modelNameForAPI := modelItem.Name
+		if modelItem.ModelName != "" {
+			modelNameForAPI = modelItem.ModelName
+		}
+		req["model"] = modelNameForAPI
 		modifiedBody, err := json.Marshal(req)
 		if err != nil {
 			lastErr = fmt.Errorf("failed to marshal request: %w", err)

--- a/ai-gateway/internal/service/model.go
+++ b/ai-gateway/internal/service/model.go
@@ -128,6 +128,7 @@ func (s *ModelService) BatchCreate(channelID int64, modelNames []string, modelTy
 			modelReq := &model.ModelRequest{
 				ChannelID: channelID,
 				Name:      name,
+			ModelName: name,
 				Type:      modelType,
 				Enabled:   1,
 			}

--- a/ai-gateway/internal/service/model.go
+++ b/ai-gateway/internal/service/model.go
@@ -91,6 +91,10 @@ func (s *ModelService) GetByName(name string) (*model.Model, error) {
 	return s.repo.GetByName(name)
 }
 
+func (s *ModelService) GetByModelName(modelName string) (*model.Model, error) {
+	return s.repo.GetByModelName(modelName)
+}
+
 func (s *ModelService) GetByNamePrefix(prefix string) ([]*model.Model, error) {
 	return s.repo.GetByNamePrefix(prefix)
 }


### PR DESCRIPTION
## Summary
- Dispatcher uses model_name for routing instead of name
- Batch create now sets model_name equal to name for upstream routing
- Extra ratings API improvements

## Changes
- ai-gateway/internal/service/dispatcher.go - Use model_name for routing
- ai-gateway/internal/repository/model_repo.go - Improved model queries
- ai-gateway/internal/service/model.go - Batch create fix