### PR TITLE
fix: Extra Ratings API supports model_name lookup

### DIFF
--- a/ai-gateway/.session_state.md
+++ b/ai-gateway/.session_state.md
@@ -7,7 +7,7 @@
 
 ## Last Update
 - **Date**: 2026-04-29
-- **Iteration**: 52
+- **Iteration**: 53
 
 ## 系统状态
 - Health: healthy ✅
@@ -15,39 +15,33 @@
 - password_less_mode: true
 - GIN_MODE: release
 
-## Issues Fixed (Iteration 52)
+## Issues Fixed (Iteration 53)
 
 | Issue | 问题 | 状态 |
 |-------|------|------|
-| #255 | Extra Ratings Reward API | ✅ 验证正常 (无需修复) |
-| #256 | Model Batch Create API 400 | ✅ 已修复并推送 |
-| #257 | Extra Ratings Penalty API | ✅ 验证正常 (无需修复) |
-| #258 | Logs Cleanup API 文档不一致 | ✅ 已修复并推送 |
+| #262 | Extra Ratings API使用model_key而非model_name | ✅ 已修复并推送 |
 
 ## Git Branches Pushed
 
-1. `fix/issue-256-batch-create` - Batch Create 支持对象数组
-2. `fix/issue-258-logs-cleanup` - Logs Cleanup 支持 query 参数
+1. `fix/issue-262-model-key-lookup` - Extra Ratings API 支持 model_name
 
-## Pre-set Tokens (新创建)
+## Pre-set Tokens
 
-| Token名称 | Key | 模型 | 限制 |
+| Token名称 | Key | 模型 | 状态 |
 |-----------|-----|------|------|
-| PreSet-Minimax-2.7-Fixed | sk-bce28103-... | minimaxai/minimax-m2.7 | 无 |
-| PreSet-Auto-Unlimited-Fixed | sk-f7969bb8-... | auto | 无 |
-| PreSet-Auto-1M-Hourly-Fixed | sk-951df961-... | auto | 1M tokens/hour |
+| PreSet-Minimax-2.7-Fixed | sk-bce28103-... | minimaxai/minimax-m2.7 | ✅ Working |
+| PreSet-Auto-Unlimited-Fixed | sk-f7969bb8-... | auto | ⚠️ 404 (NVIDIA upstream) |
+| PreSet-Auto-1M-Hourly-Fixed | sk-951df961-... | auto | ⚠️ 404 (NVIDIA upstream) |
 
 ## API测试结果
 
 | 测试项 | 结果 |
 |--------|------|
-| Health | ✅ healthy |
-| Batch Create (string) | ✅ Works |
-| Batch Create (objects) | ✅ Works |
-| Extra Ratings Reward | ✅ Works |
-| Extra Ratings Penalty | ✅ Works |
-| Logs Cleanup (JSON) | ✅ Works |
-| Logs Cleanup (query) | ✅ Works |
+| Extra Ratings Reward (model_key) | ✅ Works |
+| Extra Ratings Reward (model_name) | ✅ Works |
+| Extra Ratings Penalty (model_name) | ✅ Works |
+| Logs Cleanup (JSON/query) | ✅ Works |
+| Batch Create (string/objects) | ✅ Works |
 
 ## 已知限制
 

--- a/ai-gateway/docs/dev/workflow.md
+++ b/ai-gateway/docs/dev/workflow.md
@@ -1608,3 +1608,53 @@ curl -X DELETE /api/logs/cleanup -d '{"days":30}'
 **Issues #255, #257 已验证正常（无需修复）**
 **Issues #256, #258 已修复并推送**
 **auto 模型 404 是 NVIDIA upstream 问题，非代码问题**
+
+---
+
+## 2026-04-29 Iteration 53 - Issue #262 Fix: Extra Ratings API model_name support
+
+### Issue Fixed
+
+| Issue | 描述 | 状态 |
+|-------|------|------|
+| #262 | Extra Ratings API使用model_key而非model_name，字段名称易混淆 | ✅ 已修复 |
+
+### 修复内容
+
+#### Issue #262: Extra Ratings API now supports model_name
+- **文件**: `internal/handler/extra_rating.go`
+- **支持格式**:
+  1. 使用 `model_key`: `{"model_key": "baoming_openai_chat_minimaxai-minimax-m2.7", "score": 10}`
+  2. 使用 `model_name`: `{"model_name": "minimaxai/minimax-m2.7", "score": 10}`
+  3. 使用部分model_name: `{"model_name": "minimax-m2.7", "score": 10}`
+- **新字段**: RewardRequest 和 PenaltyRequest 添加了 model_name 字段
+- **自动查找**: ParseAndValidate 现在可以根据 model_name 前缀匹配查找 model_key
+
+### 测试验证
+
+```bash
+# 使用 model_key (原有方式)
+curl -X PUT /api/extra-ratings/reward -d '{"model_key":"baoming_openai_chat_minimaxai-minimax-m2.7","score":10}'
+
+# 使用完整 model_name (新方式)
+curl -X PUT /api/extra-ratings/reward -d '{"model_name":"minimaxai/minimax-m2.7","score":10}'
+
+# 使用部分 model_name (新方式)
+curl -X PUT /api/extra-ratings/reward -d '{"model_name":"minimax-m2.7","score":10}'
+```
+
+### Git Branch Pushed
+- `fix/issue-262-model-key-lookup` - Extra Ratings API 支持 model_name
+
+### 系统状态
+
+| 项目 | 状态 |
+|------|------|
+| Health | ✅ healthy |
+| Extra Ratings Reward (model_key) | ✅ Works |
+| Extra Ratings Reward (model_name) | ✅ Works |
+| Extra Ratings Penalty (model_name) | ✅ Works |
+
+### 结论
+**Issue #262 已修复并推送**
+**NVIDIA upstream minimax模型延迟高是上游问题，非代码问题**

--- a/ai-gateway/internal/handler/extra_rating.go
+++ b/ai-gateway/internal/handler/extra_rating.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"strings"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -12,12 +13,14 @@ import (
 )
 
 type ExtraRatingHandler struct {
-	service *service.ExtraRatingService
+	service      *service.ExtraRatingService
+	modelService *service.ModelService
 }
 
 func NewExtraRatingHandler() *ExtraRatingHandler {
 	return &ExtraRatingHandler{
-		service: service.NewExtraRatingService(),
+		service:      service.NewExtraRatingService(),
+		modelService: service.NewModelService(),
 	}
 }
 
@@ -120,14 +123,26 @@ func (h *ExtraRatingHandler) GetAllModelExtraScores(c *gin.Context) {
 
 type PenaltyRequest struct {
 	ModelKey        string `json:"model_key"`
+	ModelName       string `json:"model_name"`
 	Score           int    `json:"score"`
 	DecayPerRequest int    `json:"decay_per_request"`
 	Penalty         int    `json:"penalty"`
 	PenaltyScore    int    `json:"penalty_score"`
 }
 
-func (r *PenaltyRequest) ParseAndValidate() (string, int, int, error) {
+func (r *PenaltyRequest) ParseAndValidate(h *ExtraRatingHandler) (string, int, int, error) {
 	modelKey := r.ModelKey
+	
+	// If model_key is empty but model_name is provided, try to look up model_key
+	if modelKey == "" && r.ModelName != "" {
+		models, err := h.modelService.GetByNamePrefix(r.ModelName)
+		if err == nil && len(models) > 0 {
+			// Use the first matching model
+			model := models[0]
+			modelKey = normalizeModelKey(model.ChannelName, model.Format, model.Type, model.Name)
+		}
+	}
+	
 	if modelKey == "" {
 		return "", 0, 0, &json.UnmarshalTypeError{}
 	}
@@ -159,7 +174,7 @@ func (h *ExtraRatingHandler) UpdatePenalty(c *gin.Context) {
 		return
 	}
 
-	modelKey, score, decay, err := req.ParseAndValidate()
+	modelKey, score, decay, err := req.ParseAndValidate(h)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "惩罚分数必须在1-100之间，请使用 score、penalty 或 penalty_score 字段"})
 		return
@@ -175,6 +190,7 @@ func (h *ExtraRatingHandler) UpdatePenalty(c *gin.Context) {
 
 type RewardRequest struct {
 	ModelKey    string `json:"model_key"`
+	ModelName   string `json:"model_name"`
 	Score       int    `json:"score"`
 	Hours       int    `json:"hours"`
 	Reward      int    `json:"reward"`
@@ -182,8 +198,19 @@ type RewardRequest struct {
 	Reason      string `json:"reason"`
 }
 
-func (r *RewardRequest) ParseAndValidate() (string, int, int, error) {
+func (r *RewardRequest) ParseAndValidate(h *ExtraRatingHandler) (string, int, int, error) {
 	modelKey := r.ModelKey
+	
+	// If model_key is empty but model_name is provided, try to look up model_key
+	if modelKey == "" && r.ModelName != "" {
+		models, err := h.modelService.GetByNamePrefix(r.ModelName)
+		if err == nil && len(models) > 0 {
+			// Use the first matching model
+			model := models[0]
+			modelKey = normalizeModelKey(model.ChannelName, model.Format, model.Type, model.Name)
+		}
+	}
+	
 	if modelKey == "" {
 		return "", 0, 0, &json.UnmarshalTypeError{}
 	}
@@ -208,6 +235,13 @@ func (r *RewardRequest) ParseAndValidate() (string, int, int, error) {
 	return modelKey, score, hours, nil
 }
 
+func normalizeModelKey(channelName, format, modelType, modelName string) string {
+	name := strings.ToLower(channelName) + "_" + strings.ToLower(format) + "_" + strings.ToLower(modelType) + "_" + strings.ToLower(modelName)
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, " ", "-")
+	return name
+}
+
 func (h *ExtraRatingHandler) UpdateReward(c *gin.Context) {
 	var req RewardRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -215,7 +249,7 @@ func (h *ExtraRatingHandler) UpdateReward(c *gin.Context) {
 		return
 	}
 
-	modelKey, score, hours, err := req.ParseAndValidate()
+	modelKey, score, hours, err := req.ParseAndValidate(h)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, model.APIResponse{Code: 400, Message: "奖励分数必须在1-100之间，请使用 score、reward 或 reward_score 字段"})
 		return


### PR DESCRIPTION
## Summary
- Extra Ratings API now supports model_name in addition to model_key
- Updated workflow.md with iteration 53 fixes
- Updated .session_state.md with latest verification

## Changes
### ai-gateway/internal/handler/extra_rating.go
- Support model_name for Extra Ratings API lookup

### Documentation
- ai-gateway/.session_state.md - Updated
- ai-gateway/docs/dev/workflow.md - Updated