### PR TITLE
release: v2.32.0 - Extra Ratings API route fix

### DIFF
--- a/ai-gateway/CHANGELOG.md
+++ b/ai-gateway/CHANGELOG.md
@@ -6,10 +6,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-04-17
+## [2.32.0] - 2026-05-11
+
+### Fixed
+- Extra Ratings API route mismatch (GET /api/extra-ratings/records)
+- Vite config manualChunks function format for rolldown compatibility
+- Frontend API consistency (/extra-rating -> /extra-ratings)
+
+## [2.31.0] - 2026-05-09
+
+### Fixed
+- Issue #301: unknown model returns 404 instead of 500
+- Dashboard password_less_mode toggle redirect
+- Docs.vue htmlContent bug
+- 流式请求不保存样本问题
+
+### Changed
+- Updated workflow.md and session_state.md documentation
+
+## [2.30.0] - 2026-05-08
+
+### Fixed
+- Extra Ratings API supports model_name lookup
+- Batch create API improvements
+- Logs cleanup API improvements
+
+### Changed
+- gofmt fixes in extra_rating.go and model.go
+
+## [2.29.0] - 2026-05-07
+
+### Fixed
+- GetNextModelSmart returns error instead of silent fallback
+- Smart dispatch improvements
+- Dispatcher streaming samples fix
+
+## [2.28.0] - 2026-05-06
+
+### Changed
+- Added gin.ReleaseMode for production
+- Disabled demo channel
+- Updated version string
+
+## [2.0.0] - 2026-04-17
 
 ### Added
-- Initial release
 - AI Gateway with multi-provider support (OpenAI, Anthropic, NVIDIA, MiniMax)
 - Smart model routing based on scoring
 - Token management system
@@ -25,3 +66,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Environment-based secret management
 - JWT authentication
 - API key authentication for external access
+
+## [1.0.0] - 2026-04-17
+
+### Added
+- Initial release

--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ScoreRoute一键安装脚本v2.31.0 完全自动化
+# ScoreRoute一键安装脚本v2.32.0 完全自动化
 set -e
 
 RED='\033[0;31m'
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 show_banner() {
-    echo -e "${GREEN}ScoreRoute一键安装v2.31.0${NC}"
+    echo -e "${GREEN}ScoreRoute一键安装v2.32.0${NC}"
 }
 
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }


### PR DESCRIPTION
## Version 2.32.0

### Fixed
- Extra Ratings API route mismatch (GET /api/extra-ratings/records)
- Vite config manualChunks function format for rolldown compatibility
- Frontend API consistency (/extra-rating -> /extra-ratings)

### Files Changed
- CHANGELOG.md: Added v2.32.0 section
- install.sh: Updated version from v2.31.0 to v2.32.0