### PR TITLE
release: v2.33.0 - Release packaging, reverse proxy, dashboard stats

### DIFF
--- a/ai-gateway/CHANGELOG.md
+++ b/ai-gateway/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2.33.0] - 2026-05-12
+
+### Fixed
+- Release packaging: include web/dist in tarball (#282)
+- Reverse proxy configuration guide (#313)
+- Dashboard stats API endpoint (#333)
+
+### Changed
+- Updated session state documentation
+
 ## [2.32.0] - 2026-05-11
 
 ### Fixed

--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ScoreRoute一键安装脚本v2.32.0 完全自动化
+# ScoreRoute一键安装脚本v2.33.0 完全自动化
 set -e
 
 RED='\033[0;31m'
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 show_banner() {
-    echo -e "${GREEN}ScoreRoute一键安装v2.32.0${NC}"
+    echo -e "${GREEN}ScoreRoute一键安装v2.33.0${NC}"
 }
 
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }


### PR DESCRIPTION
## Version 2.33.0

### Fixed
- **#282**: Release packaging - include web/dist in tarball
- **#313**: Reverse proxy configuration guide
- **#333**: Dashboard stats API endpoint

### Changed
- CHANGELOG.md: Added v2.33.0 section
- install.sh: Updated version from v2.32.0 to v2.33.0