### PR TITLE
release: v2.34.0 - selectBestFromPrefixModels fix + reverse proxy guide

### DIFF
--- a/ai-gateway/CHANGELOG.md
+++ b/ai-gateway/CHANGELOG.md
@@ -6,15 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2.34.0] - 2026-05-13
+
+### Fixed
+- Issue #270: selectBestFromPrefixModels returns error instead of silent degradation
+- Issue #313: Add reverse proxy configuration guide for production deployment
+
 ## [2.33.0] - 2026-05-12
 
 ### Fixed
-- Release packaging: include web/dist in tarball (#282)
-- Reverse proxy configuration guide (#313)
-- Dashboard stats API endpoint (#333)
-
-### Changed
-- Updated session state documentation
+- Issue #282: Release packaging - include web/dist in tarball
+- Issue #313: Reverse proxy configuration guide
+- Issue #333: Dashboard stats API endpoint
 
 ## [2.32.0] - 2026-05-11
 
@@ -30,9 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dashboard password_less_mode toggle redirect
 - Docs.vue htmlContent bug
 - 流式请求不保存样本问题
-
-### Changed
-- Updated workflow.md and session_state.md documentation
 
 ## [2.30.0] - 2026-05-08
 

--- a/ai-gateway/install.sh
+++ b/ai-gateway/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ScoreRoute一键安装脚本v2.33.0 完全自动化
+# ScoreRoute一键安装脚本v2.34.0 完全自动化
 set -e
 
 RED='\033[0;31m'
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 show_banner() {
-    echo -e "${GREEN}ScoreRoute一键安装v2.33.0${NC}"
+    echo -e "${GREEN}ScoreRoute一键安装v2.34.0${NC}"
 }
 
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }


### PR DESCRIPTION
## Version 2.34.0

### Fixed
- **#270**: selectBestFromPrefixModels returns error instead of silent degradation
- **#313**: Add reverse proxy configuration guide

### Changed
- CHANGELOG.md: Updated to v2.34.0
- install.sh: Updated version from v2.33.0 to v2.34.0