### PR TITLE
fix: Issue #342/#340 - single model selection in selectBestFromPrefixModels

### DIFF
--- a/ai-gateway/internal/service/dispatcher.go
+++ b/ai-gateway/internal/service/dispatcher.go
@@ -327,7 +327,7 @@ func (d *Dispatcher) selectBestFromPrefixModels(prefixModels []*model.Model, for
 	if len(prefixModels) == 1 {
 		d.modelRepo.IncrementCallCount(prefixModels[0].ID)
 		d.modelRepo.IncrementChannelCallCount(prefixModels[0].ChannelID)
-		return nil, fmt.Errorf("selectBestFromPrefixModels: smart mode failed: single model only")
+		return prefixModels[0], nil
 	}
 
 	config, err := d.systemConfigRepo.Get()


### PR DESCRIPTION
## Summary
- Fix Issue #342 (marked CLOSED but bug still existed)
- Fix Issue #340 (compilation error at dispatcher.go:330)

## Problem
When only one model matched the prefix in smart mode, the code returned an error instead of the single model. This caused:
1. Compilation issues (undefined `err` variable)
2. Incorrect behavior when only one model was available

## Fix
Return `prefixModels[0], nil` when only one model matches, allowing proper single-model selection.

## Testing
- Go build: SUCCESS
- API streaming: works correctly with valid token
- API non-streaming: works correctly