### PR TITLE
fix: Issue #313 - serve reverse-proxy.md via /docs/reverse-proxy.md

### DIFF
--- a/ai-gateway/internal/router/router.go
+++ b/ai-gateway/internal/router/router.go
@@ -23,6 +23,7 @@ func Setup() *gin.Engine {
 	r.StaticFile("/docs/guide.md", "./docs/guide.md")
 	r.StaticFile("/docs/api.md", "./docs/api.md")
 	r.StaticFile("/docs/faq.md", "./docs/faq.md")
+	r.StaticFile("/docs/reverse-proxy.md", "./docs/reverse-proxy.md")
 	r.StaticFile("/docs/changelog.md", "./docs/changelog.md")
 	r.StaticFile("/docs/dev/setup.md", "./docs/dev/setup.md")
 	r.StaticFile("/docs/dev/architecture.md", "./docs/dev/architecture.md")


### PR DESCRIPTION
## Summary
Fix Issue #313 - Add reverse proxy configuration guide for production deployment

## Problem
The reverse-proxy.md file existed in docs/ but was not accessible via /docs/reverse-proxy.md endpoint because it was not registered in the router.

## Fix
Added StaticFile route for reverse-proxy.md in internal/router/router.go:
```go
r.StaticFile("/docs/reverse-proxy.md", "./docs/reverse-proxy.md")
```

## Testing
Build succeeds. Router now serves the reverse-proxy.md documentation.