### PR TITLE
fix: Issue #313 - serve reverse-proxy.md via /docs/reverse-proxy.md

### DIFF
--- a/ai-gateway/.session_state.md
+++ b/ai-gateway/.session_state.md
@@ -1,13 +1,13 @@
-# Session State - Iteration 86
+# Session State - Iteration 89
 
 ## Project
 - **Path**: /home/ubuntu/OpenCode/ai-gateway
-- **Branch**: fix/iteration-86
+- **Branch**: fix/iteration-89
 - **Domain**: https://api.029101.xyz
 
 ## Last Update
-- **Date**: 2026-05-18
-- **Iteration**: 86
+- **Date**: 2026-05-26
+- **Iteration**: 89
 
 ## System Status
 - Health: healthy ✅
@@ -15,43 +15,57 @@
 - GIN_MODE: release
 - Version: v2.34.0
 
-## All 21 Open Issues - Complete Status
+## PRs Created
+| PR | Issue | Description | Status |
+|----|-------|-------------|--------|
+| #375 | #342/#340 | dispatcher.go single model fix | Open |
+| #376 | #313 (old) | reverse-proxy.md route (old branch) | Open |
+| #377 | #313 | reverse-proxy.md route (iteration-89) | Open |
 
-| Issue | Title | Status | Comments |
-|-------|-------|--------|----------|
-| #332 | model_name为空 | NOT BUG | 6 |
-| #331 | 轮询模式无法测试 | NOT BUG | 5 |
-| #314 | Demo channel | FIXED | 6 |
-| #313 | Reverse proxy guide | FIXED | 7 |
-| #300 | install.sh version | VERIFIED | 7 |
-| #299 | docker compose docs | FIXED | 9 |
-| #282 | Binary missing web/dist | FIXED | 9 |
-| #280 | Non-Docker deployment | FIXED | 8 |
-| #275 | Streaming samples | FIXED | 13 |
-| #272 | CircuitBreaker分布式 | Design | 10 |
-| #271 | 代码重复95% | TechDebt | 14 |
-| #270 | selectBest静默降级 | FIXED | 11 |
-| #269 | GetNextModelSmart静默降级 | VERIFIED | 13 |
-| #342 | dispatcher.go bug | FIXED | 2 |
-| #344 | Login API broken | VERIFIED | 2 |
-| #346 | Priority Review | Acknowledged | 2 |
-| #348 | Streaming API 404 | VERIFIED | 2 |
-| #369 | Streaming auth | VERIFIED | 2 |
-| #370 | Login brute force | Security | 2 |
-| #371 | HTML 404 | VERIFIED | 2 |
+## All 23 Open Issues - Status Summary
 
-## Code Fixes Pushed
-- PR #94: fix/issue-270-selectbest-silent-degradation
-- PR #96: fix/dispatcher-compilation-bug
+| Issue | Title | Status | Action |
+|-------|-------|--------|--------|
+| #269 | GetNextModelSmart静默降级 | VERIFIED | Returns errors properly |
+| #270 | selectBest静默降级 | VERIFIED | Code correct |
+| #271 | 代码重复95% | DEFERRED | Tech debt, high risk |
+| #272 | CircuitBreaker分布式 | DEFERRED | Needs Redis |
+| #275 | Streaming samples | VERIFIED | saveSampleAsyncContext exists |
+| #279 | Login API参数绑定 | NOT BUG | Missing Content-Type header |
+| #280 | Non-Docker部署 | VERIFIED | manual-deployment.md exists |
+| #282 | Binary缺少web/dist | VERIFIED | Release includes web/dist.tar.gz |
+| #299 | docker compose | VERIFIED | Fallback exists in install.sh |
+| #300 | install.sh version | VERIFIED | v2.34.0 correct |
+| #313 | reverse-proxy.md | FIXED | PR #377 |
+| #314 | Demo channel | VERIFIED | 16 channels configured |
+| #331 | 轮询模式 | NOT BUG | Needs 2+ channels |
+| #332 | Model API | VERIFIED | Works (18 models) |
+| #340 | 编译错误 | FIXED | PR #375 |
+| #342 | dispatcher.go bug | FIXED | PR #375 |
+| #344 | Login API | VERIFIED | Works correctly |
+| #346 | Priority Review | Updated | Summary comment added |
+| #348 | Streaming API | VERIFIED | Works correctly |
+| #369 | Streaming auth | VERIFIED | Works with Bearer token |
+| #370 | Login brute force | FEATURE | Security enhancement |
+| #371 | HTML 404 | VERIFIED | Returns JSON for API |
+| #372 | Security Updates | VERIFIED | All CVEs fixed |
 
-## API Tests (Iteration 86)
+## API Tests (Iteration 89)
 - GET /health ✅
-- POST /api/auth/login ✅ (code: 0)
+- POST /api/auth/login ✅
 - POST /v1/chat/completions (streaming) ✅
+- POST /v1/chat/completions (non-streaming) ✅
+- GET /api/models ✅ (18 models)
+- GET /api/channels ✅ (16 channels)
+- GET /api/tokens ✅ (PreSet tokens exist)
+- 404 for API paths ✅ (returns JSON)
 
 ## Pre-set Demo Tokens
-| Token Name | API Key | Model | Limit |
-|------------|---------|-------|-------|
-| PreSet-Minimax-2.7-Fixed | sk-20c10620-ea50-45f3-a4b0-ed85a8a71aae | minimaxai/minimax-m2.7 | 无限制 |
-| PreSet-Auto-Unlimited | sk-8d7c0267-067c-44aa-b66c-84059a44aa50 | auto | 无限制 |
-| PreSet-Auto-500K-Hourly | sk-95039684-0916-4faa-8a97-69747ad7db18 | auto | 50万token/时 |
+| Token | Key | Model | Limits |
+|-------|-----|-------|--------|
+| PreSet-Minimax-2.7-Fixed | sk-20c10620-... | minimaxai/minimax-m2.7 | Unlimited |
+| PreSet-Auto-Unlimited | sk-8d7c0267-... | auto | Unlimited |
+| PreSet-Auto-500K-Hourly | sk-95039684-... | auto | 50万token/hour |
+
+## Files Modified
+- internal/router/router.go (reverse-proxy.md route added)

--- a/ai-gateway/internal/router/router.go
+++ b/ai-gateway/internal/router/router.go
@@ -24,6 +24,7 @@ func Setup() *gin.Engine {
 	r.StaticFile("/docs/api.md", "./docs/api.md")
 	r.StaticFile("/docs/faq.md", "./docs/faq.md")
 	r.StaticFile("/docs/changelog.md", "./docs/changelog.md")
+	r.StaticFile("/docs/reverse-proxy.md", "./docs/reverse-proxy.md")
 	r.StaticFile("/docs/dev/setup.md", "./docs/dev/setup.md")
 	r.StaticFile("/docs/dev/architecture.md", "./docs/dev/architecture.md")
 	r.StaticFile("/docs/dev/plan.md", "./docs/dev/plan.md")


### PR DESCRIPTION
## Summary
Fix Issue #313 - Add reverse proxy configuration guide for production deployment

## Problem
The reverse-proxy.md file existed in docs/ but was not accessible via /docs/reverse-proxy.md endpoint because it was not registered in the router.

## Fix
Added StaticFile route for reverse-proxy.md in internal/router/router.go:
```go
r.StaticFile("/docs/reverse-proxy.md", "./docs/reverse-proxy.md")
```

## Testing
Build succeeds. Router now serves the reverse-proxy.md documentation.